### PR TITLE
Lazy reap on join conflict + swarm reap CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Workspace management:
   swarm rename-workspace <id> <title>         Rename a workspace
 
 Session:
+  swarm reap [--name <agent>] [--force]       Prune dead agents after liveness probe
   swarm reset                                 Clear all agents and messages
   swarm help                                  Show help
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { getDb } from './db.js';
-import { joinAgent, leaveAgent, getSelf, getAgent, listAgents, listAgentsSync, updateStatus, updateHeartbeat, updateWorkspace, joinA2AAgent, leaveA2AAgent, joinHeadlessAgent, leaveHeadlessAgent } from './registry.js';
+import { joinAgent, leaveAgent, getSelf, getAgent, listAgents, listAgentsSync, updateStatus, updateHeartbeat, updateWorkspace, joinA2AAgent, leaveA2AAgent, joinHeadlessAgent, leaveHeadlessAgent, reapIfDead, reapAll, forceReap } from './registry.js';
 import { sendMessage, broadcastMessage, getInbox } from './mailbox.js';
 import { readScreen, identify, spawnWorkspace, renameTab, moveSurface, listWorkspaces, renameWorkspace, sendToSurface, sleep } from './transport.js';
 import { installHook, removeHook, detectHost } from './hooks.js';
@@ -76,6 +76,7 @@ Cmux-only:
   swarm rename-workspace <id> <title>              Rename a workspace
 
 Admin:
+  swarm reap [--name <agent>] [--force]            Prune dead agents after liveness probe
   swarm reset                                      Clear all agents and messages
   swarm help                                       Show this help`);
 }
@@ -115,9 +116,17 @@ async function main() {
         const headless = hasFlag('--headless');
         const description = getFlag('--description');
         const db = getDb();
+
+        // Lazy reap first so a dead cmux/a2a registration with this name doesn't
+        // block rejoin. Skips headless agents (no probeable surface).
+        const reaped = await reapIfDead(db, name);
+        if (reaped) {
+          console.log(`Reaped stale "${reaped.name}" (${reaped.agent_type}) — surface was dead.`);
+        }
+
         const existing = getAgent(db, name);
         if (existing && existing.agent_type === 'a2a') {
-          console.error(`Agent "${name}" is already registered as an A2A agent. Choose a different name or run "swarm unregister-a2a ${name}" first.`);
+          console.error(`Agent "${name}" is already registered as a live A2A agent. Choose a different name or run "swarm unregister-a2a ${name}" first.`);
           process.exit(1);
         }
 
@@ -200,6 +209,10 @@ async function main() {
         }
 
         const db = getDb();
+        const reaped = await reapIfDead(db, name);
+        if (reaped) {
+          console.log(`Reaped stale "${reaped.name}" (${reaped.agent_type}) — surface was dead.`);
+        }
         const agent = joinA2AAgent(db, name, endpoint, agentDescription);
         console.log(`Registered A2A agent "${agent.name}" @ ${endpoint}`);
         break;
@@ -459,6 +472,62 @@ async function main() {
         } catch (err: any) {
           console.error(`Failed to rename workspace: ${err.message}`);
           process.exit(1);
+        }
+        break;
+      }
+
+      case 'reap': {
+        const db = getDb();
+        const name = getFlag('--name');
+        const force = hasFlag('--force');
+
+        if (force && !name) {
+          console.error('Usage: swarm reap --name <agent> --force  (--force requires --name)');
+          process.exit(1);
+        }
+
+        if (name) {
+          if (force) {
+            const removed = forceReap(db, name);
+            if (removed) {
+              // Clean up headless side effects (hook + terminal surface) so operators
+              // using --force as the sanctioned headless-removal escape hatch don't
+              // leave stale swarm-awareness state pointing at a deleted agent.
+              if (removed.agent_type === 'headless') {
+                removeSurface(removed.name);
+                const host = detectHost();
+                if (host) removeHook(host, removed.name);
+              }
+              console.log(`Force-reaped "${removed.name}" (${removed.agent_type}).`);
+            } else {
+              console.error(`No agent named "${name}" found.`);
+              process.exit(1);
+            }
+          } else {
+            const removed = await reapIfDead(db, name);
+            if (removed) {
+              console.log(`Reaped "${removed.name}" (${removed.agent_type}) — surface confirmed dead.`);
+            } else {
+              const still = getAgent(db, name);
+              if (!still) {
+                console.error(`No agent named "${name}" found.`);
+                process.exit(1);
+              } else if (still.agent_type === 'headless') {
+                console.error(`"${name}" is a headless agent; has no probeable surface. Use --force to remove.`);
+                process.exit(1);
+              } else {
+                console.log(`"${name}" is alive; not reaped. Use --force to remove anyway.`);
+              }
+            }
+          }
+        } else {
+          const removed = await reapAll(db);
+          if (removed.length === 0) {
+            console.log('No dead agents found.');
+          } else {
+            console.log(`Reaped ${removed.length} agent(s):`);
+            for (const a of removed) console.log(`  ${a.name} (${a.agent_type})`);
+          }
         }
         break;
       }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -57,19 +57,23 @@ export function joinAgent(
   agentType: AgentType = 'cmux',
   endpointUrl?: string
 ): Agent {
-  // Check if name is already taken by a different agent
-  const existing = getAgent(db, name);
-  if (existing && existing.surface_id !== surfaceId) {
-    throw new Error(`Agent name "${name}" is already taken by a ${existing.agent_type} agent. Choose a different name.`);
-  }
-
   const id = randomUUID();
   const now = new Date().toISOString();
 
-  db.prepare(`
-    INSERT OR REPLACE INTO agents (id, name, description, surface_id, workspace_id, ppid, joined_at, last_heartbeat, agent_type, endpoint_url)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, name, description ?? null, surfaceId, workspaceId ?? null, ppid, now, now, agentType, endpointUrl ?? null);
+  // Atomic check-and-insert. Without this, two terminals racing to claim the
+  // same name after a reap can both read an empty slot and both insert —
+  // INSERT OR REPLACE lets the second silently overwrite the first.
+  const tx = db.transaction(() => {
+    const existing = getAgent(db, name);
+    if (existing && existing.surface_id !== surfaceId) {
+      throw new Error(`Agent name "${name}" is already taken by a ${existing.agent_type} agent. Choose a different name.`);
+    }
+    db.prepare(`
+      INSERT OR REPLACE INTO agents (id, name, description, surface_id, workspace_id, ppid, joined_at, last_heartbeat, agent_type, endpoint_url)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, name, description ?? null, surfaceId, workspaceId ?? null, ppid, now, now, agentType, endpointUrl ?? null);
+  });
+  tx.immediate();
 
   return { id, name, description: description ?? null, agent_type: agentType, endpoint_url: endpointUrl ?? null, surface_id: surfaceId, workspace_id: workspaceId ?? null, ppid, joined_at: now, last_heartbeat: now };
 }
@@ -225,4 +229,65 @@ async function cleanupStale(db: Database.Database): Promise<void> {
   });
 
   await Promise.all(checks);
+}
+
+/**
+ * Probe an agent's liveness twice back-to-back. Returns true only if both probes fail.
+ * Used by the lazy-reap path where we need higher confidence than a single probe —
+ * isSurfaceAlive already retries once internally, so this gives us up to 4 attempts
+ * before declaring an agent dead.
+ */
+async function isConfirmedDead(agent: Agent): Promise<boolean> {
+  const probe = async (): Promise<boolean> =>
+    agent.agent_type === 'a2a'
+      ? await isAgentAlive(agent)
+      : isSurfaceAlive(agent.surface_id, agent.workspace_id);
+  if (await probe()) return false;
+  return !(await probe());
+}
+
+/**
+ * If an agent with this name exists, is not headless, and fails two back-to-back
+ * liveness probes, delete it. Called on the join-conflict path so a stale entry
+ * from a dead surface doesn't block rejoin. Returns the reaped agent or null.
+ * Headless agents are skipped — they have no surface to probe.
+ */
+export async function reapIfDead(db: Database.Database, name: string): Promise<Agent | null> {
+  const existing = getAgent(db, name);
+  if (!existing) return null;
+  if (existing.agent_type === 'headless') return null;
+  if (await isConfirmedDead(existing)) {
+    db.prepare('DELETE FROM agents WHERE id = ?').run(existing.id);
+    failedChecks.delete(existing.id);
+    return existing;
+  }
+  return null;
+}
+
+/** Reap all non-headless agents that fail two back-to-back liveness probes. */
+export async function reapAll(db: Database.Database): Promise<Agent[]> {
+  const agents = db.prepare('SELECT * FROM agents').all() as Agent[];
+  const reaped: Agent[] = [];
+  for (const agent of agents) {
+    if (agent.agent_type === 'headless') continue;
+    if (await isConfirmedDead(agent)) {
+      db.prepare('DELETE FROM agents WHERE id = ?').run(agent.id);
+      failedChecks.delete(agent.id);
+      reaped.push(agent);
+    }
+  }
+  return reaped;
+}
+
+/**
+ * Force-delete an agent by name without probing. Escape hatch for operators who
+ * know an entry is stale (e.g., after a cmux crash). Removes any agent type,
+ * including headless. Returns the removed agent or null.
+ */
+export function forceReap(db: Database.Database, name: string): Agent | null {
+  const existing = getAgent(db, name);
+  if (!existing) return null;
+  db.prepare('DELETE FROM agents WHERE id = ?').run(existing.id);
+  failedChecks.delete(existing.id);
+  return existing;
 }

--- a/tests/swarm.test.ts
+++ b/tests/swarm.test.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { getDbAt } from '../src/db.js';
-import { joinAgent, leaveAgent, getAgent, listAgents, updateStatus, joinA2AAgent, leaveA2AAgent } from '../src/registry.js';
+import { joinAgent, leaveAgent, getAgent, listAgents, updateStatus, joinA2AAgent, leaveA2AAgent, joinHeadlessAgent, reapIfDead, reapAll, forceReap } from '../src/registry.js';
 import { getInbox } from '../src/mailbox.js';
 import type Database from 'better-sqlite3';
 
@@ -132,6 +132,110 @@ describe('registry', () => {
     assert.strictEqual(removed, true);
     const agent = getAgent(db, 'Cooper');
     assert.strictEqual(agent, null);
+  });
+});
+
+describe('reap', () => {
+  test('reapIfDead removes a cmux agent with a dead surface', async () => {
+    // In the test environment cmux is unavailable, so isSurfaceAlive fails.
+    joinAgent(db, 'Ghost', 'surface-fake', 'workspace-1', process.ppid);
+    const reaped = await reapIfDead(db, 'Ghost');
+    assert.ok(reaped, 'expected agent to be reaped');
+    assert.strictEqual(reaped.name, 'Ghost');
+    assert.strictEqual(getAgent(db, 'Ghost'), null);
+  });
+
+  test('reapIfDead returns null for a nonexistent agent', async () => {
+    const reaped = await reapIfDead(db, 'DoesNotExist');
+    assert.strictEqual(reaped, null);
+  });
+
+  test('reapIfDead skips headless agents', async () => {
+    // Set SWARM_AGENT_NAME so joinHeadlessAgent doesn't try to write a TTY marker
+    const prev = process.env.SWARM_AGENT_NAME;
+    process.env.SWARM_AGENT_NAME = 'Ephemeral';
+    try {
+      joinHeadlessAgent(db, 'Ephemeral');
+    } finally {
+      if (prev === undefined) delete process.env.SWARM_AGENT_NAME;
+      else process.env.SWARM_AGENT_NAME = prev;
+    }
+    const reaped = await reapIfDead(db, 'Ephemeral');
+    assert.strictEqual(reaped, null, 'headless agents must not be reaped');
+    assert.ok(getAgent(db, 'Ephemeral'), 'headless agent should still exist');
+  });
+
+  test('reapIfDead is case-insensitive', async () => {
+    joinAgent(db, 'Ghost', 'surface-fake', 'workspace-1', process.ppid);
+    const reaped = await reapIfDead(db, 'GHOST');
+    assert.ok(reaped);
+    assert.strictEqual(reaped.name, 'Ghost');
+  });
+
+  test('reapAll prunes cmux agents but keeps headless', async () => {
+    joinAgent(db, 'GhostA', 'surface-a', 'workspace-1', process.ppid);
+    joinAgent(db, 'GhostB', 'surface-b', 'workspace-1', process.ppid);
+    const prev = process.env.SWARM_AGENT_NAME;
+    process.env.SWARM_AGENT_NAME = 'Keeper';
+    try {
+      joinHeadlessAgent(db, 'Keeper');
+    } finally {
+      if (prev === undefined) delete process.env.SWARM_AGENT_NAME;
+      else process.env.SWARM_AGENT_NAME = prev;
+    }
+
+    const reaped = await reapAll(db);
+    const reapedNames = reaped.map(a => a.name).sort();
+    assert.deepStrictEqual(reapedNames, ['GhostA', 'GhostB']);
+    assert.strictEqual(getAgent(db, 'GhostA'), null);
+    assert.strictEqual(getAgent(db, 'GhostB'), null);
+    assert.ok(getAgent(db, 'Keeper'), 'headless agent must survive reapAll');
+  });
+
+  test('reapAll on empty db returns empty array', async () => {
+    const reaped = await reapAll(db);
+    assert.deepStrictEqual(reaped, []);
+  });
+
+  test('forceReap deletes an agent without probing', () => {
+    joinAgent(db, 'Victim', 'surface-x', 'workspace-1', process.ppid);
+    const removed = forceReap(db, 'Victim');
+    assert.ok(removed);
+    assert.strictEqual(removed.name, 'Victim');
+    assert.strictEqual(getAgent(db, 'Victim'), null);
+  });
+
+  test('forceReap returns null for unknown agent', () => {
+    assert.strictEqual(forceReap(db, 'NoOne'), null);
+  });
+
+  test('forceReap can delete a headless agent', () => {
+    const prev = process.env.SWARM_AGENT_NAME;
+    process.env.SWARM_AGENT_NAME = 'Stuck';
+    try {
+      joinHeadlessAgent(db, 'Stuck');
+    } finally {
+      if (prev === undefined) delete process.env.SWARM_AGENT_NAME;
+      else process.env.SWARM_AGENT_NAME = prev;
+    }
+    const removed = forceReap(db, 'Stuck');
+    assert.ok(removed, 'forceReap must work on headless agents as an escape hatch');
+    assert.strictEqual(getAgent(db, 'Stuck'), null);
+  });
+
+  test('rejoin succeeds after reaping a dead entry with the same name', async () => {
+    joinAgent(db, 'Lead', 'old-surface', 'workspace-1', process.ppid, 'old task');
+    // Simulate: cmux restart gives Lead a new surface id. Direct rejoin would fail.
+    assert.throws(
+      () => joinAgent(db, 'Lead', 'new-surface', 'workspace-1', process.ppid, 'new task'),
+      { message: /already taken/ }
+    );
+    // After reap (old surface is fake = dead), rejoin succeeds.
+    await reapIfDead(db, 'Lead');
+    joinAgent(db, 'Lead', 'new-surface', 'workspace-1', process.ppid, 'new task');
+    const agent = getAgent(db, 'Lead');
+    assert.strictEqual(agent?.surface_id, 'new-surface');
+    assert.strictEqual(agent?.description, 'new task');
   });
 });
 


### PR DESCRIPTION
## Summary

- Dead cmux/a2a entries previously blocked rejoin for ~30 min (needed 3 consecutive probe failures + stale heartbeat). Now the join path confirms the stale surface is dead with two back-to-back probes and removes it automatically.
- New `swarm reap [--name <agent>] [--force]` CLI as an explicit escape hatch. `--force` also cleans up headless hooks/surfaces so operators can't leave orphaned swarm-awareness state pointing at a deleted agent.
- `joinAgent` check-and-insert now runs in an `IMMEDIATE` SQLite transaction so two terminals racing to claim the same name after a reap can't silently overwrite each other.
- Headless agents are skipped by all auto-reap paths (no probeable surface); `forceReap` can still remove them.

## Why

Per Lead's request after yesterday's incident: a dead surface for "Lead" prevented rejoin even though cmux was gone. Root cause was in `registry.ts:60` — name-collision check ran before any liveness check.

## Codex review + challenge

Codex review flagged (both fixed): dead A2A entries still blocked join because the a2a-conflict check ran before `reapIfDead`; force-reaping a headless agent left stale hooks/surfaces. Codex adversarial challenge surfaced the concurrent-join race (now fixed with the `IMMEDIATE` transaction). Other challenge findings are pre-existing bugs outside this PR's scope — flagged to Lead separately: shell/SQL injection via agent name in `hooks.ts`, path traversal via agent name in `registerSurface`, and A2A `isAlive()` treating 500 as alive.

## Test plan

- [x] `npm test` — 32/32 pass (10 new reap tests)
- [x] `npm run build` — clean
- [x] Manual: `swarm reap`, `swarm reap --name X`, `swarm reap --name X --force`, `swarm reap --force` (usage error)
- [ ] Reviewer should exercise: rejoin by a previously-stuck name with a live peer trying to claim the same name at the same time

🤖 Generated with [Claude Code](https://claude.com/claude-code)