### PR TITLE
Finalize multi-swarm/headless/locking; fix 8 review-found bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Swarm supports these transport modes:
 - **Warp agents** register as headless terminal agents with Warp surface metadata. `swarm spawn --terminal warp` opens a new Warp tab via `warp://action/new_tab`; push delivery is deferred, so messages queue for `swarm inbox`.
 - **A2A agents** (OpenClaw, Hermes, etc.) register via `swarm register-a2a <name> --endpoint <url>`. Messages are delivered via the A2A protocol over HTTP. This enables cross-user and cross-machine coordination.
 
-Stale agents are cleaned up by checking liveness (Cmux surface check or A2A agent card ping) combined with a 10-minute heartbeat threshold.
+Stale agents are cleaned up by checking liveness (Cmux surface check or A2A agent card ping) combined with a 30-minute heartbeat threshold (confirmed with a second probe before removal). Headless agents have no probeable surface and are never auto-pruned.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Swarm supports two transport types:
 - **Cmux agents** (Claude Code, Codex) register via `swarm join <name>`, which stores their Cmux surface ID in SQLite (`~/.swarm/swarm.db`). Messages are pushed via `cmux send` + `cmux send-key Enter`.
 - **A2A agents** (OpenClaw, Hermes, etc.) register via `swarm register-a2a <name> --endpoint <url>`. Messages are delivered via the A2A protocol over HTTP. This enables cross-user and cross-machine coordination.
 
-Stale agents are cleaned up by checking liveness (Cmux surface check or A2A agent card ping) combined with a 10-minute heartbeat threshold.
+Stale agents are cleaned up by checking liveness (Cmux surface check or A2A agent card ping) combined with a 30-minute heartbeat threshold, and only after several consecutive failed liveness probes. Headless agents are never auto-pruned (they have no probeable surface).
 
 ## Architecture
 

--- a/hooks/swarm-awareness-headless.sh
+++ b/hooks/swarm-awareness-headless.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 SWARM_BIN="$(cd "$(dirname "$0")/.." && pwd)/bin/swarm"
-"$SWARM_BIN" hook-context 2>/dev/null
+# `|| true` keeps this a clean no-op after leaving the swarm: hook-context exits 1
+# (requireSelf) when the session isn't joined, and a nonzero hook exit is just noise.
+"$SWARM_BIN" hook-context 2>/dev/null || true

--- a/hooks/swarm-awareness.sh
+++ b/hooks/swarm-awareness.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 SWARM_BIN="$(cd "$(dirname "$0")/.." && pwd)/bin/swarm"
-"$SWARM_BIN" hook-context 2>/dev/null
+# `|| true` keeps this a clean no-op after leaving the swarm: hook-context exits 1
+# (requireSelf) when the session isn't joined, and a nonzero hook exit is just noise.
+"$SWARM_BIN" hook-context 2>/dev/null || true

--- a/src/applescript-transport.ts
+++ b/src/applescript-transport.ts
@@ -1,5 +1,7 @@
 import childProcess from 'child_process';
 import { Transport, TransportAgent, TransportDeliveryResult } from './transport-interface.js';
+import { sanitize } from './transport.js';
+import { DEFAULT_SWARM_ID } from './db.js';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -152,12 +154,17 @@ export function removeSurface(swarmId: string, agentName: string): void {
   const scoped = surfacePath(swarmId, agentName);
   if (fs.existsSync(scoped)) fs.unlinkSync(scoped);
 
-  const legacy = legacySurfacePath(agentName);
-  if (fs.existsSync(legacy)) fs.unlinkSync(legacy);
+  // The unscoped legacy file belongs to the pre-multi-swarm (default) layout only —
+  // never delete it on behalf of a non-default swarm that merely shares an agent name.
+  if (swarmId === DEFAULT_SWARM_ID) {
+    const legacy = legacySurfacePath(agentName);
+    if (fs.existsSync(legacy)) fs.unlinkSync(legacy);
+  }
 }
 
 export function hasSurface(swarmId: string, agentName: string): boolean {
-  return fs.existsSync(surfacePath(swarmId, agentName)) || fs.existsSync(legacySurfacePath(agentName));
+  if (fs.existsSync(surfacePath(swarmId, agentName))) return true;
+  return swarmId === DEFAULT_SWARM_ID && fs.existsSync(legacySurfacePath(agentName));
 }
 
 /**
@@ -165,9 +172,12 @@ export function hasSurface(swarmId: string, agentName: string): boolean {
  */
 export function loadSurface(swarmId: string, agentName: string): AppleScriptSurface | null {
   const scoped = surfacePath(swarmId, agentName);
-  const legacy = legacySurfacePath(agentName);
-  const selectedPath = fs.existsSync(scoped) ? scoped : legacy;
-  if (!fs.existsSync(selectedPath)) return null;
+  // Only fall back to the unscoped legacy file for the default swarm, so a same-named
+  // agent in another swarm can't be delivered into the default swarm's terminal.
+  const selectedPath = fs.existsSync(scoped)
+    ? scoped
+    : (swarmId === DEFAULT_SWARM_ID ? legacySurfacePath(agentName) : null);
+  if (!selectedPath || !fs.existsSync(selectedPath)) return null;
   try {
     return JSON.parse(fs.readFileSync(selectedPath, 'utf-8'));
   } catch {
@@ -300,13 +310,18 @@ export class AppleScriptTransport implements Transport {
       return { delivered: false, error: `No terminal surface registered for ${agent.name}` };
     }
 
+    // Collapse newlines/tabs before they reach the osascript string literal — an embedded
+    // newline would break the `do script`/`write text` line or submit prematurely (the
+    // same protection the cmux socket path already applies via sanitize()).
+    const safeText = sanitize(formattedText);
+
     try {
       switch (surface.app) {
         case 'Terminal':
-          sendToTerminalApp(surface, formattedText);
+          sendToTerminalApp(surface, safeText);
           break;
         case 'iTerm2':
-          sendToITerm2(surface, formattedText);
+          sendToITerm2(surface, safeText);
           break;
         case 'Warp':
           if (!surface.pushEnabled) {

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,53 @@
+// Commands whose trailing positionals are free text (a message or title). The value is
+// the positional index (the command word is positional 0) at which the free-text tail
+// begins; once reached, no further tokens are scanned for the global --swarm/-s flag, so
+// a message like `broadcast deploy with -s now` is never truncated and never silently
+// rerouted to another swarm. Use --swarm BEFORE the message (e.g. `send --swarm x bob "hi"`).
+export const FREE_TEXT_TAIL_AT: Record<string, number> = {
+  send: 2,
+  broadcast: 1,
+  rename: 2,
+  'rename-workspace': 2,
+};
+
+/**
+ * Split the global `--swarm`/`-s` selector out of the argument list. The selector is only
+ * honored in the "flag region" — once a command's free-text tail begins (see
+ * FREE_TEXT_TAIL_AT) every remaining token is treated as literal message/title text.
+ */
+export function parseGlobalFlags(input: string[]): { args: string[]; swarmName: string | undefined } {
+  const stripped: string[] = [];
+  let swarmName: string | undefined;
+  let positionals = 0;
+  let freeTextStart = Infinity;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const arg = input[i];
+
+    // Inside a command's free-text tail every token is literal (part of the message/title).
+    if (positionals >= freeTextStart) {
+      stripped.push(arg);
+      continue;
+    }
+
+    if (arg === '--swarm' || arg === '-s') {
+      swarmName = input[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--swarm=')) {
+      swarmName = arg.slice('--swarm='.length);
+      continue;
+    }
+
+    stripped.push(arg);
+    if (!arg.startsWith('-')) {
+      if (positionals === 0 && Object.prototype.hasOwnProperty.call(FREE_TEXT_TAIL_AT, arg)) {
+        freeTextStart = FREE_TEXT_TAIL_AT[arg];
+      }
+      positionals += 1;
+    }
+  }
+
+  return { args: stripped, swarmName };
+}

--- a/src/cmux-transport.ts
+++ b/src/cmux-transport.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'child_process';
 import { Transport, TransportAgent, TransportDeliveryResult } from './transport-interface.js';
-import { sendToSurface, SurfaceGoneError, isSurfaceAlive } from './transport.js';
+import { sendToSurface, SurfaceGoneError, isSurfaceAlive, sanitize } from './transport.js';
 
 /**
  * Deliver a message to a Cmux tab via AppleScript clipboard paste.
@@ -10,8 +10,9 @@ import { sendToSurface, SurfaceGoneError, isSurfaceAlive } from './transport.js'
  * via Cmd+<number> before pasting. Requires: cmux app running, System Events access.
  */
 function deliverViaAppleScript(agent: TransportAgent, text: string): void {
-  // Escape for AppleScript string (backslashes and quotes)
-  const escaped = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  // Collapse newlines/tabs (the socket path sanitizes; this fallback must too), then
+  // escape for the AppleScript string literal (backslashes and quotes).
+  const escaped = sanitize(text).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
   // Parse workspace index from workspace_id (e.g., "workspace:2" → 2)
   let switchTabScript = '';

--- a/src/db.ts
+++ b/src/db.ts
@@ -106,35 +106,53 @@ function migrateAgents(db: Database.Database): void {
   const columns = tableColumns(db, 'agents');
   if (columns.has('swarm_id')) return;
 
-  db.exec(`
-    CREATE TABLE agents_new (
-      id TEXT PRIMARY KEY,
-      swarm_id TEXT NOT NULL,
-      name TEXT NOT NULL COLLATE NOCASE,
-      description TEXT,
-      surface_id TEXT NOT NULL,
-      workspace_id TEXT,
-      ppid INTEGER NOT NULL,
-      joined_at TEXT NOT NULL,
-      last_heartbeat TEXT NOT NULL,
-      agent_type TEXT NOT NULL DEFAULT 'cmux',
-      endpoint_url TEXT,
-      FOREIGN KEY (swarm_id) REFERENCES swarms(id) ON DELETE CASCADE,
-      UNIQUE (swarm_id, name)
-    );
+  // Run the rebuild atomically (DDL is transactional in SQLite). The leading
+  // DROP ... IF EXISTS clears any half-built table from a prior interrupted/failed
+  // run; without atomicity a failed INSERT would leave agents_new committed and
+  // permanently wedge every future migrate() with "table agents_new already exists".
+  db.transaction(() => {
+    db.exec(`
+      DROP TABLE IF EXISTS agents_new;
 
-    INSERT INTO agents_new (
-      id, swarm_id, name, description, surface_id, workspace_id, ppid,
-      joined_at, last_heartbeat, agent_type, endpoint_url
-    )
-    SELECT
-      id, '${DEFAULT_SWARM_ID}', name, description, surface_id, workspace_id, ppid,
-      joined_at, last_heartbeat, agent_type, endpoint_url
-    FROM agents;
+      CREATE TABLE agents_new (
+        id TEXT PRIMARY KEY,
+        swarm_id TEXT NOT NULL,
+        name TEXT NOT NULL COLLATE NOCASE,
+        description TEXT,
+        surface_id TEXT NOT NULL,
+        workspace_id TEXT,
+        ppid INTEGER NOT NULL,
+        joined_at TEXT NOT NULL,
+        last_heartbeat TEXT NOT NULL,
+        agent_type TEXT NOT NULL DEFAULT 'cmux',
+        endpoint_url TEXT,
+        FOREIGN KEY (swarm_id) REFERENCES swarms(id) ON DELETE CASCADE,
+        UNIQUE (swarm_id, name)
+      );
 
-    DROP TABLE agents;
-    ALTER TABLE agents_new RENAME TO agents;
-  `);
+      -- The new schema makes name COLLATE NOCASE UNIQUE(swarm_id,name); the legacy schema
+      -- used a case-sensitive UNIQUE, so a legacy DB could hold 'Bob' and 'bob'. Keep one
+      -- row per case-insensitive name (the most recently active) so the INSERT can't trip
+      -- the NOCASE unique constraint and leave the migration permanently failing.
+      INSERT INTO agents_new (
+        id, swarm_id, name, description, surface_id, workspace_id, ppid,
+        joined_at, last_heartbeat, agent_type, endpoint_url
+      )
+      SELECT
+        id, '${DEFAULT_SWARM_ID}', name, description, surface_id, workspace_id, ppid,
+        joined_at, last_heartbeat, agent_type, endpoint_url
+      FROM agents a
+      WHERE NOT EXISTS (
+        SELECT 1 FROM agents b
+        WHERE b.name = a.name COLLATE NOCASE AND b.id <> a.id
+          AND (b.last_heartbeat > a.last_heartbeat
+               OR (b.last_heartbeat = a.last_heartbeat AND b.id > a.id))
+      );
+
+      DROP TABLE agents;
+      ALTER TABLE agents_new RENAME TO agents;
+    `);
+  })();
 }
 
 function migrateMessages(db: Database.Database): void {
@@ -146,25 +164,29 @@ function migrateMessages(db: Database.Database): void {
   const columns = tableColumns(db, 'messages');
   if (columns.has('swarm_id')) return;
 
-  db.exec(`
-    CREATE TABLE messages_new (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      swarm_id TEXT NOT NULL,
-      from_agent TEXT NOT NULL,
-      to_agent TEXT,
-      body TEXT NOT NULL,
-      delivered INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL,
-      FOREIGN KEY (swarm_id) REFERENCES swarms(id) ON DELETE CASCADE
-    );
+  db.transaction(() => {
+    db.exec(`
+      DROP TABLE IF EXISTS messages_new;
 
-    INSERT INTO messages_new (id, swarm_id, from_agent, to_agent, body, delivered, created_at)
-    SELECT id, '${DEFAULT_SWARM_ID}', from_agent, to_agent, body, delivered, created_at
-    FROM messages;
+      CREATE TABLE messages_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        swarm_id TEXT NOT NULL,
+        from_agent TEXT NOT NULL,
+        to_agent TEXT,
+        body TEXT NOT NULL,
+        delivered INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY (swarm_id) REFERENCES swarms(id) ON DELETE CASCADE
+      );
 
-    DROP TABLE messages;
-    ALTER TABLE messages_new RENAME TO messages;
-  `);
+      INSERT INTO messages_new (id, swarm_id, from_agent, to_agent, body, delivered, created_at)
+      SELECT id, '${DEFAULT_SWARM_ID}', from_agent, to_agent, body, delivered, created_at
+      FROM messages;
+
+      DROP TABLE messages;
+      ALTER TABLE messages_new RENAME TO messages;
+    `);
+  })();
 }
 
 function migrateInboxCursors(db: Database.Database): void {
@@ -176,22 +198,34 @@ function migrateInboxCursors(db: Database.Database): void {
   const columns = tableColumns(db, 'inbox_cursors');
   if (columns.has('swarm_id')) return;
 
-  db.exec(`
-    CREATE TABLE inbox_cursors_new (
-      swarm_id TEXT NOT NULL,
-      agent_name TEXT NOT NULL COLLATE NOCASE,
-      last_read_id INTEGER NOT NULL DEFAULT 0,
-      FOREIGN KEY (swarm_id) REFERENCES swarms(id) ON DELETE CASCADE,
-      PRIMARY KEY (swarm_id, agent_name)
-    );
+  db.transaction(() => {
+    db.exec(`
+      DROP TABLE IF EXISTS inbox_cursors_new;
 
-    INSERT INTO inbox_cursors_new (swarm_id, agent_name, last_read_id)
-    SELECT '${DEFAULT_SWARM_ID}', agent_name, last_read_id
-    FROM inbox_cursors;
+      CREATE TABLE inbox_cursors_new (
+        swarm_id TEXT NOT NULL,
+        agent_name TEXT NOT NULL COLLATE NOCASE,
+        last_read_id INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (swarm_id) REFERENCES swarms(id) ON DELETE CASCADE,
+        PRIMARY KEY (swarm_id, agent_name)
+      );
 
-    DROP TABLE inbox_cursors;
-    ALTER TABLE inbox_cursors_new RENAME TO inbox_cursors;
-  `);
+      -- inbox_cursors.agent_name is now COLLATE NOCASE in the PRIMARY KEY; dedupe legacy
+      -- case-variant cursors (keep the furthest-read) so the INSERT cannot violate the PK.
+      INSERT INTO inbox_cursors_new (swarm_id, agent_name, last_read_id)
+      SELECT '${DEFAULT_SWARM_ID}', agent_name, last_read_id
+      FROM inbox_cursors a
+      WHERE NOT EXISTS (
+        SELECT 1 FROM inbox_cursors b
+        WHERE b.agent_name = a.agent_name COLLATE NOCASE AND b.agent_name <> a.agent_name
+          AND (b.last_read_id > a.last_read_id
+               OR (b.last_read_id = a.last_read_id AND b.agent_name > a.agent_name))
+      );
+
+      DROP TABLE inbox_cursors;
+      ALTER TABLE inbox_cursors_new RENAME TO inbox_cursors;
+    `);
+  })();
 }
 
 function migrate(db: Database.Database): void {

--- a/src/headless-transport.ts
+++ b/src/headless-transport.ts
@@ -3,7 +3,8 @@ import { Transport, TransportAgent, TransportDeliveryResult } from './transport-
 /**
  * Headless transport — no push delivery. Messages are stored in the DB
  * and picked up by the agent via `swarm inbox` (polled by the awareness hook).
- * isAlive checks heartbeat freshness since there's no surface to ping.
+ * There is no surface to ping, so isAlive always returns true and headless agents
+ * are never auto-pruned by registry.cleanupStale.
  */
 export class HeadlessTransport implements Transport {
   async deliverMessage(_agent: TransportAgent, _formattedText: string): Promise<TransportDeliveryResult> {
@@ -13,8 +14,9 @@ export class HeadlessTransport implements Transport {
   }
 
   async isAlive(_agent: TransportAgent): Promise<boolean> {
-    // Headless agents are alive as long as their heartbeat is fresh.
-    // The stale cleanup in registry.ts handles expiry via heartbeat threshold.
+    // Headless agents have no probeable surface, so they are treated as alive and are
+    // never auto-pruned by registry.cleanupStale (which skips agent_type === 'headless').
+    // Stale headless rows are cleared only by an explicit reap or a same-name re-join.
     return true;
   }
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -65,7 +65,9 @@ function ensureHeadlessHook(): void {
   const quotedSwarmBin = shellDoubleQuote(swarmBin);
   const script = `#!/usr/bin/env bash
 # Swarm awareness hook (headless) — runs on UserPromptSubmit
-${quotedSwarmBin} hook-context 2>/dev/null
+# \`|| true\` keeps it a clean no-op after leaving the swarm (hook-context exits 1 when
+# this session isn't joined).
+${quotedSwarmBin} hook-context 2>/dev/null || true
 `;
 
   fs.writeFileSync(HOOK_SCRIPT, script, { mode: 0o755 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,29 +35,9 @@ import { readScreen, identify, spawnSurfaceInWorkspace, spawnWorkspace, renameTa
 import { installHook, removeHook, detectHost } from './hooks.js';
 import { registerSurface, removeSurface, loadSurface as loadSurfaceForHook } from './applescript-transport.js';
 import { ensureCodexTrust } from './codex-trust.js';
+import { parseGlobalFlags } from './args.js';
 
 const rawArgs = process.argv.slice(2);
-
-function parseGlobalFlags(input: string[]): { args: string[]; swarmName: string | undefined } {
-  const stripped: string[] = [];
-  let swarmName: string | undefined;
-
-  for (let i = 0; i < input.length; i += 1) {
-    const arg = input[i];
-    if (arg === '--swarm' || arg === '-s') {
-      swarmName = input[i + 1];
-      i += 1;
-      continue;
-    }
-    if (arg.startsWith('--swarm=')) {
-      swarmName = arg.slice('--swarm='.length);
-      continue;
-    }
-    stripped.push(arg);
-  }
-
-  return { args: stripped, swarmName };
-}
 
 const parsed = parseGlobalFlags(rawArgs);
 const args = parsed.args;
@@ -156,10 +136,10 @@ Swarm Management:
 
 Agent Management:
   swarm join <name> [--description <text>]        Register in the selected swarm
-    [--headless] [--push] [--root <path>]         Force headless / opt into Warp push / set root
+    [--headless] [--push] [--force] [--root <path>]  Force headless / Warp push / reclaim name / set root
   swarm leave                                      Deregister from the current swarm
   swarm register-a2a <name> --endpoint <url>       Register an A2A agent
-    [--description <text>]
+    [--description <text>] [--force]
   swarm unregister-a2a <name>                      Remove an A2A agent
   swarm discover <url>                             Fetch and display an A2A agent card
 
@@ -210,7 +190,7 @@ function writeWarpOscTitle(surface: { ttyDevice?: string }, swarmName: string, a
 }
 
 function joinAsHeadless(db: ReturnType<typeof getDb>, swarm: Swarm, name: string, description?: string, pushEnabled?: boolean): void {
-  const agent = joinHeadlessAgent(db, swarm.id, name, description);
+  const agent = joinHeadlessAgent(db, swarm.id, name, description, { trackSession: true });
   const parts: string[] = [`swarm: ${swarm.name}`, 'headless'];
 
   const surface = registerSurface(swarm.id, name, pushEnabled);
@@ -233,6 +213,34 @@ function joinAsHeadless(db: ReturnType<typeof getDb>, swarm: Swarm, name: string
   if (!surface && !host) {
     console.log('Tip: Run "swarm inbox" periodically to check for messages.');
   }
+}
+
+// Headless registrations can't be liveness-probed (no surface to ping) and are orphaned by
+// a session resume (the controlling TTY changes, so the per-TTY identity marker no longer
+// resolves) — leaving the name registered but un-reclaimable, and blocking re-join under the
+// same name. Reclaiming a headless name lets the agent re-attach, but because we can't tell a
+// dead orphan from a busy-but-live agent (the heartbeat only refreshes on a prompt turn, not
+// during a long autonomous task), reclaiming ALWAYS requires explicit --force. That way a
+// same-name join from a different session can never silently knock out an active agent.
+function reclaimHeadlessNameOrExit(
+  db: ReturnType<typeof getDb>,
+  swarm: Swarm,
+  existing: Agent | null,
+  force: boolean
+): void {
+  if (!existing || existing.agent_type !== 'headless') return;
+
+  if (!force) {
+    const mins = Math.max(1, Math.round((Date.now() - new Date(existing.last_heartbeat).getTime()) / 60000));
+    console.error(`Agent "${existing.name}" is already held by a headless agent (last active ~${mins} min ago). If this is your prior session (e.g. you resumed into Cmux) or you are sure it is gone, re-run with --force to reclaim the name; otherwise choose a different name.`);
+    process.exit(1);
+  }
+
+  forceReap(db, swarm.id, existing.name);
+  removeSurface(swarm.id, existing.name);
+  const priorHost = detectHost();
+  if (priorHost) removeHook(priorHost, existing.name, swarm.id);
+  console.log(`Reclaimed headless registration "${existing.name}" from a prior session.`);
 }
 
 function printHookContext(): void {
@@ -313,11 +321,12 @@ async function main() {
       case 'join': {
         const name = args[1];
         if (!name) {
-          console.error('Usage: swarm join <name> [--description <text>] [--headless] [--push] [--swarm <name>]');
+          console.error('Usage: swarm join <name> [--description <text>] [--headless] [--push] [--force] [--swarm <name>]');
           process.exit(1);
         }
         const headless = hasFlag('--headless');
         const pushEnabled = hasFlag('--push');
+        const force = hasFlag('--force');
         const description = getFlag('--description');
         const db = getDb();
         const swarm = explicitSwarmName
@@ -334,6 +343,8 @@ async function main() {
           console.error(`Agent "${name}" is already registered as a live A2A agent in swarm "${swarm.name}". Choose a different name or run "swarm unregister-a2a ${name} --swarm ${swarm.name}" first.`);
           process.exit(1);
         }
+
+        reclaimHeadlessNameOrExit(db, swarm, existing, force);
 
         if (headless) {
           joinAsHeadless(db, swarm, name, description, pushEnabled);
@@ -353,7 +364,7 @@ async function main() {
       case 'leave': {
         const { db, self, swarm } = requireSelf();
         if (self.agent_type === 'headless') {
-          leaveHeadlessAgent(db, self.swarm_id, self.name);
+          leaveHeadlessAgent(db, self.swarm_id, self.name, { trackSession: true });
           removeSurface(self.swarm_id, self.name);
           const host = detectHost();
           if (host) {
@@ -370,7 +381,7 @@ async function main() {
         const name = args[1];
         const endpoint = getFlag('--endpoint');
         if (!name || !endpoint) {
-          console.error('Usage: swarm register-a2a <name> --endpoint <url> [--description <text>] [--swarm <name>]');
+          console.error('Usage: swarm register-a2a <name> --endpoint <url> [--description <text>] [--force] [--swarm <name>]');
           process.exit(1);
         }
 
@@ -415,6 +426,7 @@ async function main() {
         if (reaped) {
           console.log(`Reaped stale "${reaped.name}" (${reaped.agent_type}) from swarm "${swarm.name}" — surface was dead.`);
         }
+        reclaimHeadlessNameOrExit(db, swarm, getAgent(db, swarm.id, name), hasFlag('--force'));
         const agent = joinA2AAgent(db, swarm.id, name, endpoint, agentDescription);
         console.log(`Registered A2A agent "${agent.name}" in swarm "${swarm.name}" @ ${endpoint}`);
         break;
@@ -486,7 +498,11 @@ async function main() {
           process.exit(1);
         }
         const result = await broadcastMessage(db, self.swarm_id, self.name, message);
-        console.log(`Broadcast to ${result.sent} agent(s)${result.failed > 0 ? `, ${result.failed} failed` : ''}`);
+        const reached = result.sent + result.queued;
+        let line = `Broadcast to ${reached} agent(s)`;
+        if (result.queued > 0) line += ` (${result.queued} via inbox)`;
+        if (result.failed > 0) line += `, ${result.failed} failed`;
+        console.log(line);
         break;
       }
 
@@ -808,17 +824,28 @@ async function main() {
       }
 
       case 'rename-workspace': {
-        const wsId = args[1];
+        const givenId = args[1];
         const title = args.slice(2).join(' ');
-        if (!wsId || !title) {
+        if (!givenId || !title) {
           console.error('Usage: swarm rename-workspace <workspace-id> <title>');
           process.exit(1);
+        }
+        const db = getDb();
+        // `swarm whoami` prints both a Surface id and a Workspace id; agents frequently
+        // pass the Surface id by mistake (cmux then fails with "Workspace not found").
+        // If the given id matches a known agent's surface, resolve to its workspace id.
+        let wsId = givenId;
+        const bySurface = db.prepare('SELECT name, workspace_id FROM agents WHERE surface_id = ? LIMIT 1')
+          .get(givenId) as { name: string; workspace_id: string | null } | undefined;
+        if (bySurface?.workspace_id && bySurface.workspace_id !== givenId) {
+          wsId = bySurface.workspace_id;
+          console.log(`Note: "${givenId}" is ${bySurface.name}'s Surface id; using their Workspace id ${wsId}.`);
         }
         try {
           renameWorkspace(wsId, title);
           console.log(`Renamed workspace ${wsId} to "${title}"`);
         } catch (err: any) {
-          console.error(`Failed to rename workspace: ${err.message}`);
+          console.error(`Failed to rename workspace ${wsId}: ${err.message} (Tip: pass the Workspace id from "swarm whoami", not the Surface id.)`);
           process.exit(1);
         }
         break;

--- a/src/mailbox.ts
+++ b/src/mailbox.ts
@@ -27,9 +27,13 @@ export async function sendMessage(
   const now = new Date().toISOString();
   const formatted = `[SWARM from ${fromName}]: ${body}`;
 
+  // Store the canonical registered name (getAgent matches case-insensitively).
+  // messages.to_agent is compared case-sensitively in getInbox, so persisting the
+  // raw sender-typed casing would make a case-mismatched message invisible to the
+  // recipient's inbox while still reporting success.
   const result = db.prepare(
     'INSERT INTO messages (swarm_id, from_agent, to_agent, body, delivered, created_at) VALUES (?, ?, ?, ?, 0, ?)'
-  ).run(swarmId, fromName, toName, body, now);
+  ).run(swarmId, fromName, target.name, body, now);
 
   const msgId = result.lastInsertRowid;
 
@@ -53,12 +57,12 @@ export async function broadcastMessage(
   swarmId: string,
   fromName: string,
   body: string
-): Promise<{ sent: number; failed: number }> {
+): Promise<{ sent: number; queued: number; failed: number }> {
   const agents = await listAgents(db, swarmId);
   const recipients = agents.filter(a => a.name !== fromName);
 
   if (recipients.length === 0) {
-    return { sent: 0, failed: 0 };
+    return { sent: 0, queued: 0, failed: 0 };
   }
 
   const now = new Date().toISOString();
@@ -73,21 +77,31 @@ export async function broadcastMessage(
 
   // Deliver to all recipients in parallel
   const results = await Promise.all(
-    recipients.map(agent => deliverToAgent(agent, formatted))
+    recipients.map(async agent => ({ agent, result: await deliverToAgent(agent, formatted) }))
   );
 
   let sent = 0;
+  let queued = 0;
   let failed = 0;
-  for (const r of results) {
-    if (r.delivered) sent++;
-    else failed++;
+  for (const { agent, result } of results) {
+    if (result.delivered) {
+      sent++;
+    } else if (agent.agent_type === 'a2a') {
+      // A2A agents can't read the local inbox, so a failed push is a real miss.
+      failed++;
+    } else {
+      // Cmux/headless: the broadcast row is in the DB and is inbox-readable
+      // (to_agent IS NULL), so the recipient still receives it on their next
+      // inbox poll even though the immediate push nudge failed. Mirrors sendMessage.
+      queued++;
+    }
   }
 
-  if (sent > 0) {
+  if (sent + queued > 0) {
     db.prepare('UPDATE messages SET delivered = 1 WHERE id = ?').run(msgId);
   }
 
-  return { sent, failed };
+  return { sent, queued, failed };
 }
 
 export function getInbox(
@@ -102,11 +116,13 @@ export function getInbox(
   const lastReadId = cursor?.last_read_id ?? 0;
 
   // Fetch messages: direct messages to me + broadcasts, after cursor, not from me
+  // Match names case-insensitively (agents register COLLATE NOCASE) so a message addressed
+  // with non-canonical casing still lands, and an agent never sees its own messages.
   const messages = db.prepare(`
     SELECT * FROM messages
     WHERE swarm_id = ?
-      AND (to_agent = ? OR to_agent IS NULL)
-      AND from_agent != ?
+      AND (to_agent = ? COLLATE NOCASE OR to_agent IS NULL)
+      AND from_agent != ? COLLATE NOCASE
       AND id > ?
     ORDER BY created_at ASC
   `).all(swarmId, agentName, agentName, lastReadId) as Message[];

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -39,6 +39,17 @@ interface SessionMarker {
   agent_name: string;
 }
 
+/**
+ * Options for headless join/leave. The per-TTY session marker is a fallback
+ * identity mechanism for interactive terminals that have no SWARM_AGENT_NAME
+ * injected by a hook. Only the interactive CLI session should manage it; pure
+ * DB callers (tests, programmatic use, batch registration) must not, otherwise
+ * multiple agents sharing a controlling TTY would reap each other on join.
+ */
+export interface HeadlessSessionOptions {
+  trackSession?: boolean;
+}
+
 function nowIso(): string {
   return new Date().toISOString();
 }
@@ -49,7 +60,6 @@ function normalizeSwarmName(name?: string | null): string {
 }
 
 function getSessionMarkerPath(): string | null {
-  if (process.env.SWARM_DISABLE_SESSION_MARKER === '1') return null;
   try {
     let pid = process.ppid?.toString() || '';
     for (let i = 0; i < 5 && pid; i++) {
@@ -260,12 +270,17 @@ export function joinHeadlessAgent(
   db: Database.Database,
   swarmId: string,
   name: string,
-  description?: string
+  description?: string,
+  options: HeadlessSessionOptions = {}
 ): Agent {
-  const currentMarker = readSessionMarker();
-  if (currentMarker && (currentMarker.swarm_id !== swarmId || currentMarker.agent_name.toLowerCase() !== name.toLowerCase())) {
-    db.prepare("DELETE FROM agents WHERE swarm_id = ? AND name = ? COLLATE NOCASE AND agent_type = 'headless'")
-      .run(currentMarker.swarm_id, currentMarker.agent_name);
+  if (options.trackSession) {
+    // This TTY previously joined under a different identity — reap it so a
+    // single interactive session never leaves a ghost behind after a rename.
+    const currentMarker = readSessionMarker();
+    if (currentMarker && (currentMarker.swarm_id !== swarmId || currentMarker.agent_name.toLowerCase() !== name.toLowerCase())) {
+      db.prepare("DELETE FROM agents WHERE swarm_id = ? AND name = ? COLLATE NOCASE AND agent_type = 'headless'")
+        .run(currentMarker.swarm_id, currentMarker.agent_name);
+    }
   }
 
   const existing = getAgent(db, swarmId, name);
@@ -274,14 +289,23 @@ export function joinHeadlessAgent(
   }
   const syntheticSurfaceId = `headless:${swarmId}:${name}`;
   const agent = joinAgent(db, swarmId, name, syntheticSurfaceId, undefined, process.ppid, description, 'headless');
-  writeSessionMarker(swarmId, name);
+  if (options.trackSession) {
+    writeSessionMarker(swarmId, name);
+  }
   return agent;
 }
 
-export function leaveHeadlessAgent(db: Database.Database, swarmId: string, name: string): boolean {
+export function leaveHeadlessAgent(
+  db: Database.Database,
+  swarmId: string,
+  name: string,
+  options: HeadlessSessionOptions = {}
+): boolean {
   const result = db.prepare("DELETE FROM agents WHERE swarm_id = ? AND name = ? COLLATE NOCASE AND agent_type = 'headless'")
     .run(swarmId, name);
-  removeSessionMarker(swarmId, name);
+  if (options.trackSession) {
+    removeSessionMarker(swarmId, name);
+  }
   return result.changes > 0;
 }
 
@@ -300,7 +324,10 @@ export function getSelf(db: Database.Database, swarmId?: string): Agent | null {
       ? 'SELECT * FROM agents WHERE swarm_id = ? AND surface_id = ? ORDER BY joined_at DESC LIMIT 1'
       : 'SELECT * FROM agents WHERE surface_id = ? ORDER BY joined_at DESC LIMIT 1';
     const params = resolvedSwarmId ? [resolvedSwarmId, surfaceId] : [surfaceId];
-    return db.prepare(sql).get(...params) as Agent | undefined ?? null;
+    const bySurface = db.prepare(sql).get(...params) as Agent | undefined;
+    if (bySurface) return bySurface;
+    // No Cmux agent owns this surface — fall through to the headless resolution paths so an
+    // agent that joined with `--headless` from inside a Cmux tab can still find itself.
   }
 
   const agentName = process.env.SWARM_AGENT_NAME;
@@ -362,8 +389,6 @@ export function updateHeartbeat(db: Database.Database, swarmId: string, surfaceI
 }
 
 const STALE_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
-const failedChecks = new Map<string, number>();
-const REQUIRED_FAILURES = 3;
 
 async function cleanupStale(db: Database.Database, swarmId?: string): Promise<void> {
   const agents = swarmId
@@ -372,29 +397,30 @@ async function cleanupStale(db: Database.Database, swarmId?: string): Promise<vo
   const now = Date.now();
 
   const checks = agents.map(async (agent) => {
-    if (agent.agent_type === 'headless') return;
+    if (agent.agent_type === 'headless') return; // no probeable surface; never auto-pruned
 
-    let alive: boolean;
-    if (agent.agent_type === 'a2a') {
-      alive = await isAgentAlive(agent);
-    } else {
-      alive = isSurfaceAlive(agent.surface_id, agent.workspace_id);
+    // First probe. Cmux heartbeats are refreshed by the awareness hook; A2A heartbeats
+    // are only refreshed here, so bump them whenever the endpoint is reachable.
+    const aliveNow = agent.agent_type === 'a2a'
+      ? await isAgentAlive(agent)
+      : isSurfaceAlive(agent.surface_id, agent.workspace_id);
+    if (aliveNow) {
+      if (agent.agent_type === 'a2a') updateHeartbeat(db, agent.swarm_id, agent.surface_id);
+      return;
     }
 
-    if (alive) {
-      failedChecks.delete(agent.id);
-      if (agent.agent_type === 'a2a') {
-        updateHeartbeat(db, agent.swarm_id, agent.surface_id);
-      }
-    } else {
-      const failures = (failedChecks.get(agent.id) ?? 0) + 1;
-      failedChecks.set(agent.id, failures);
+    // Unreachable. Only prune once the heartbeat is also stale (so a briefly-unreachable
+    // but recently-active agent is spared) AND a second probe still fails (guards against a
+    // transient socket/HTTP blip). This replaces a module-level failure counter that never
+    // accumulated across the short-lived one-shot CLI process, so auto-pruning never fired.
+    const heartbeatAge = now - new Date(agent.last_heartbeat).getTime();
+    if (heartbeatAge <= STALE_THRESHOLD_MS) return;
 
-      const heartbeatAge = now - new Date(agent.last_heartbeat).getTime();
-      if (failures >= REQUIRED_FAILURES && heartbeatAge > STALE_THRESHOLD_MS) {
-        db.prepare('DELETE FROM agents WHERE id = ?').run(agent.id);
-        failedChecks.delete(agent.id);
-      }
+    const stillDead = agent.agent_type === 'a2a'
+      ? !(await isAgentAlive(agent))
+      : !isSurfaceAlive(agent.surface_id, agent.workspace_id);
+    if (stillDead) {
+      db.prepare('DELETE FROM agents WHERE id = ?').run(agent.id);
     }
   });
 
@@ -416,7 +442,6 @@ export async function reapIfDead(db: Database.Database, swarmId: string, name: s
   if (existing.agent_type === 'headless') return null;
   if (await isConfirmedDead(existing)) {
     db.prepare('DELETE FROM agents WHERE id = ?').run(existing.id);
-    failedChecks.delete(existing.id);
     return existing;
   }
   return null;
@@ -431,7 +456,6 @@ export async function reapAll(db: Database.Database, swarmId?: string): Promise<
     if (agent.agent_type === 'headless') continue;
     if (await isConfirmedDead(agent)) {
       db.prepare('DELETE FROM agents WHERE id = ?').run(agent.id);
-      failedChecks.delete(agent.id);
       reaped.push(agent);
     }
   }
@@ -442,6 +466,5 @@ export function forceReap(db: Database.Database, swarmId: string, name: string):
   const existing = getAgent(db, swarmId, name);
   if (!existing) return null;
   db.prepare('DELETE FROM agents WHERE id = ?').run(existing.id);
-  failedChecks.delete(existing.id);
   return existing;
 }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -34,7 +34,7 @@ function resolveCmux(): string {
   );
 }
 
-function sanitize(text: string): string {
+export function sanitize(text: string): string {
   // Strip escape sequences that cmux interprets (\n -> Enter, \t -> Tab)
   // Also strip actual newlines/tabs to prevent multi-line injection
   return text
@@ -225,7 +225,21 @@ export function listWorkspaces(): string {
 
 export function renameWorkspace(workspaceId: string, title: string): void {
   const cmux = resolveCmux();
-  execFileSync(cmux, ['rename-workspace', '--workspace', workspaceId, '--', title], STDIO_OPTS);
+  try {
+    execFileSync(cmux, ['rename-workspace', '--workspace', workspaceId, '--', title], STDIO_OPTS);
+  } catch (err: any) {
+    // execFileSync only throws on a non-zero exit, so this is a genuine cmux failure
+    // (e.g. "not_found: Workspace not found" when a Surface id is passed instead of a
+    // Workspace id). The useful detail is on stderr; cmux also prints a deprecation
+    // notice there even on success, so strip that line and surface the real error.
+    const stderr: string = (err.stderr?.toString() ?? '').trim();
+    const real = stderr
+      .split('\n')
+      .filter((line: string) => !/deprecat|alias for/i.test(line))
+      .join(' ')
+      .trim();
+    throw new Error(real || err.message || `cmux rename-workspace failed for "${workspaceId}"`);
+  }
 }
 
 export function identify(): { surfaceId: string | undefined; workspaceId: string | undefined } {

--- a/tests/args.test.ts
+++ b/tests/args.test.ts
@@ -1,0 +1,68 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { parseGlobalFlags } from '../src/args.js';
+
+describe('parseGlobalFlags', () => {
+  test('extracts --swarm in the flag region', () => {
+    assert.deepStrictEqual(
+      parseGlobalFlags(['members', '--swarm', 'proj']),
+      { args: ['members'], swarmName: 'proj' }
+    );
+    assert.deepStrictEqual(
+      parseGlobalFlags(['join', 'Foo', '-s', 'proj']),
+      { args: ['join', 'Foo'], swarmName: 'proj' }
+    );
+    assert.deepStrictEqual(
+      parseGlobalFlags(['--swarm=proj', 'members']),
+      { args: ['members'], swarmName: 'proj' }
+    );
+  });
+
+  test('--swarm before the command works', () => {
+    assert.deepStrictEqual(
+      parseGlobalFlags(['--swarm', 'proj', 'send', 'bob', 'hi']),
+      { args: ['send', 'bob', 'hi'], swarmName: 'proj' }
+    );
+    assert.deepStrictEqual(
+      parseGlobalFlags(['send', '--swarm', 'proj', 'bob', 'hello there']),
+      { args: ['send', 'bob', 'hello there'], swarmName: 'proj' }
+    );
+  });
+
+  test('does NOT eat -s / --swarm tokens inside a broadcast message', () => {
+    // The exact regression: an unquoted message containing -s must survive intact.
+    assert.deepStrictEqual(
+      parseGlobalFlags(['broadcast', 'deploy', 'with', '-s', 'flag', 'now']),
+      { args: ['broadcast', 'deploy', 'with', '-s', 'flag', 'now'], swarmName: undefined }
+    );
+    assert.deepStrictEqual(
+      parseGlobalFlags(['broadcast', 'use', '--swarm', 'is', 'a', 'flag']),
+      { args: ['broadcast', 'use', '--swarm', 'is', 'a', 'flag'], swarmName: undefined }
+    );
+  });
+
+  test('does NOT eat -s tokens inside a send message (after the agent positional)', () => {
+    assert.deepStrictEqual(
+      parseGlobalFlags(['send', 'bob', 'run', 'rm', '-s', 'now']),
+      { args: ['send', 'bob', 'run', 'rm', '-s', 'now'], swarmName: undefined }
+    );
+  });
+
+  test('does NOT eat -s tokens inside rename / rename-workspace titles', () => {
+    assert.deepStrictEqual(
+      parseGlobalFlags(['rename', 'bob', 'title', '-s', 'x']),
+      { args: ['rename', 'bob', 'title', '-s', 'x'], swarmName: undefined }
+    );
+    assert.deepStrictEqual(
+      parseGlobalFlags(['rename-workspace', 'ws-1', 'my', '-s', 'title']),
+      { args: ['rename-workspace', 'ws-1', 'my', '-s', 'title'], swarmName: undefined }
+    );
+  });
+
+  test('quoted single-token message is preserved', () => {
+    assert.deepStrictEqual(
+      parseGlobalFlags(['broadcast', 'deploy with -s now']),
+      { args: ['broadcast', 'deploy with -s now'], swarmName: undefined }
+    );
+  });
+});

--- a/tests/cli-integration.test.ts
+++ b/tests/cli-integration.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, before, after } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import SQLite from 'better-sqlite3';
+
+// Exercise the real CLI handlers (join reclaim, rename-workspace id resolution) as a
+// subprocess against an isolated HOME (so ~/.swarm is a throwaway temp DB, never the
+// live swarm). cmux-dependent side effects are best-effort and not asserted on.
+const INDEX = resolve(fileURLToPath(new URL('../src/index.ts', import.meta.url)));
+
+interface CliResult { stdout: string; stderr: string; status: number; }
+
+function runCli(home: string, args: string[], env: Record<string, string> = {}): CliResult {
+  const childEnv: Record<string, string> = {
+    PATH: process.env.PATH ?? '',
+    HOME: home,
+    // Start each call from a clean identity so nothing leaks in from the test runner.
+    SWARM_ID: '', SWARM_NAME: '', SWARM_AGENT_NAME: '',
+    CMUX_SURFACE_ID: '', CMUX_WORKSPACE_ID: '', TERM_PROGRAM: '',
+    ...env,
+  };
+  try {
+    const stdout = execFileSync('node', ['--import', 'tsx', INDEX, ...args], {
+      encoding: 'utf-8', env: childEnv, stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', status: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout?.toString() ?? '',
+      stderr: err.stderr?.toString() ?? '',
+      status: typeof err.status === 'number' ? err.status : 1,
+    };
+  }
+}
+
+describe('cli integration', () => {
+  let home: string;
+  before(() => { home = mkdtempSync(join(tmpdir(), 'swarm-cli-')); });
+  after(() => { rmSync(home, { recursive: true, force: true }); });
+
+  test('a fresh (likely-live) headless holder blocks a no-force re-join', () => {
+    const j1 = runCli(home, ['join', 'Baz', '--headless'], { SWARM_AGENT_NAME: 'Baz' });
+    assert.strictEqual(j1.status, 0, j1.stderr || j1.stdout);
+
+    // Heartbeat is fresh (just joined), so a same-name join from another session must be
+    // refused — it could be a still-live agent. The error must point at --force.
+    const j2 = runCli(home, ['join', 'Baz'], { CMUX_SURFACE_ID: 'surf-baz', CMUX_WORKSPACE_ID: 'ws-baz' });
+    assert.notStrictEqual(j2.status, 0, 'fresh headless holder should block a no-force re-join');
+    assert.match(j2.stdout + j2.stderr, /--force/);
+  });
+
+  test('--force reclaims a headless-held name (resume into Cmux)', () => {
+    const j1 = runCli(home, ['join', 'Foo', '--headless'], { SWARM_AGENT_NAME: 'Foo' });
+    assert.strictEqual(j1.status, 0, j1.stderr || j1.stdout);
+    assert.match(j1.stdout, /Joined swarm .* as "Foo"/);
+
+    const j2 = runCli(home, ['join', 'Foo', '--force'], { CMUX_SURFACE_ID: 'surf-1', CMUX_WORKSPACE_ID: 'ws-1' });
+    assert.strictEqual(j2.status, 0, `--force reclaim should succeed: ${j2.stderr || j2.stdout}`);
+    assert.match(j2.stdout, /Reclaimed headless registration "Foo"/);
+    assert.doesNotMatch(j2.stdout + j2.stderr, /already taken/);
+
+    const who = runCli(home, ['whoami'], { CMUX_SURFACE_ID: 'surf-1' });
+    assert.strictEqual(who.status, 0, who.stderr || who.stdout);
+    assert.match(who.stdout, /Type: cmux/);
+  });
+
+  test('a headless holder is never auto-evicted — reclaim is --force only, even when stale', () => {
+    const j1 = runCli(home, ['join', 'Qux', '--headless'], { SWARM_AGENT_NAME: 'Qux' });
+    assert.strictEqual(j1.status, 0, j1.stderr || j1.stdout);
+
+    // Age its heartbeat far past any threshold. A headless agent has no probeable surface,
+    // so even a long-stale one is NOT auto-evicted (it could be busy on a long task) — only
+    // an explicit --force reclaims it.
+    const sqlite = new SQLite(join(home, '.swarm', 'swarm.db'));
+    sqlite.prepare("UPDATE agents SET last_heartbeat = ? WHERE name = 'Qux'")
+      .run(new Date(Date.now() - 60 * 60 * 1000).toISOString());
+    sqlite.close();
+
+    const blocked = runCli(home, ['join', 'Qux'], { CMUX_SURFACE_ID: 'surf-qux', CMUX_WORKSPACE_ID: 'ws-qux' });
+    assert.notStrictEqual(blocked.status, 0, 'a stale headless holder must still require --force');
+    assert.match(blocked.stdout + blocked.stderr, /--force/);
+
+    const forced = runCli(home, ['join', 'Qux', '--force'], { CMUX_SURFACE_ID: 'surf-qux', CMUX_WORKSPACE_ID: 'ws-qux' });
+    assert.strictEqual(forced.status, 0, forced.stderr || forced.stdout);
+    assert.match(forced.stdout, /Reclaimed headless registration "Qux"/);
+  });
+
+  test('--headless join inside a Cmux env still resolves its own identity', () => {
+    // Force headless even though a Cmux surface is present; getSelf must fall through from
+    // the surface lookup (which finds no Cmux row) to the headless resolution path.
+    const j = runCli(home, ['join', 'Hax', '--headless'], { CMUX_SURFACE_ID: 'surf-hidden', SWARM_AGENT_NAME: 'Hax' });
+    assert.strictEqual(j.status, 0, j.stderr || j.stdout);
+
+    const who = runCli(home, ['whoami'], { CMUX_SURFACE_ID: 'surf-hidden', SWARM_AGENT_NAME: 'Hax' });
+    assert.strictEqual(who.status, 0, who.stderr || who.stdout);
+    assert.match(who.stdout, /Type: headless/);
+  });
+
+  test('rename-workspace resolves a Surface id to the agent\'s Workspace id', () => {
+    const j = runCli(home, ['join', 'Bar'], { CMUX_SURFACE_ID: 'surf-bar', CMUX_WORKSPACE_ID: 'ws-bar' });
+    assert.strictEqual(j.status, 0, j.stderr || j.stdout);
+
+    // Pass the SURFACE id by mistake (whoami prints both). The CLI should detect it and
+    // substitute the agent's Workspace id, printing a note — regardless of whether the
+    // underlying cmux rename then succeeds or fails in this environment.
+    const r = runCli(home, ['rename-workspace', 'surf-bar', 'Bar'], { CMUX_SURFACE_ID: 'surf-bar' });
+    assert.match(r.stdout + r.stderr, /is Bar's Surface id; using their Workspace id ws-bar/);
+  });
+});

--- a/tests/swarm.test.ts
+++ b/tests/swarm.test.ts
@@ -19,7 +19,7 @@ import {
   reapIfDead as reapIfDeadRaw,
   updateStatus as updateStatusRaw,
 } from '../src/registry.js';
-import { getInbox as getInboxRaw } from '../src/mailbox.js';
+import { getInbox as getInboxRaw, sendMessage as sendMessageRaw } from '../src/mailbox.js';
 import type Database from 'better-sqlite3';
 
 let db: Database.Database;
@@ -72,6 +72,10 @@ function forceReap(testDb: Database.Database, name: string) {
 
 function getInbox(testDb: Database.Database, agentName: string, peek: boolean = false) {
   return getInboxRaw(testDb, SWARM_ID, agentName, peek);
+}
+
+function sendMessage(testDb: Database.Database, fromName: string, toName: string, body: string) {
+  return sendMessageRaw(testDb, SWARM_ID, fromName, toName, body);
 }
 
 beforeEach(() => {
@@ -147,20 +151,16 @@ describe('registry', () => {
   });
 
   test('stale surface cleanup removes dead agents with stale heartbeat', async () => {
-    // Insert agents with fake surfaces and stale heartbeats (>30min old)
+    // Two cmux agents with fake (unreachable) surfaces and heartbeats older than the
+    // 30min stale window. cmux is unavailable in tests, so both probe as dead.
     const staleTime = new Date(Date.now() - 35 * 60 * 1000).toISOString();
     db.prepare(`INSERT OR REPLACE INTO agents (id, swarm_id, name, description, surface_id, workspace_id, ppid, joined_at, last_heartbeat, agent_type, endpoint_url)
-      VALUES ('g1', ?, 'Ghost', NULL, 'surface-ghost', 'workspace-1', 999999, ?, ?, 'cmux', NULL)`).run(SWARM_ID, staleTime, staleTime);
+      VALUES ('g1', ?, 'GhostA', NULL, 'surface-ghost', 'workspace-1', 999999, ?, ?, 'cmux', NULL)`).run(SWARM_ID, staleTime, staleTime);
     db.prepare(`INSERT OR REPLACE INTO agents (id, swarm_id, name, description, surface_id, workspace_id, ppid, joined_at, last_heartbeat, agent_type, endpoint_url)
-      VALUES ('a1', ?, 'Alive', NULL, 'surface-alive', 'workspace-1', ${process.ppid}, ?, ?, 'cmux', NULL)`).run(SWARM_ID, staleTime, staleTime);
-    const before = db.prepare('SELECT * FROM agents').all() as any[];
-    assert.strictEqual(before.length, 2);
-    // Cleanup requires 3 consecutive failed surface checks before pruning
-    await listAgents(db); // strike 1
+      VALUES ('a1', ?, 'GhostB', NULL, 'surface-ghost-b', 'workspace-1', 999999, ?, ?, 'cmux', NULL)`).run(SWARM_ID, staleTime, staleTime);
     assert.strictEqual((db.prepare('SELECT * FROM agents').all() as any[]).length, 2);
-    await listAgents(db); // strike 2
-    assert.strictEqual((db.prepare('SELECT * FROM agents').all() as any[]).length, 2);
-    // Strike 3 — now agents should be pruned
+    // A single listAgents() confirms each dead via a double-probe and prunes it in one
+    // process — the old design needed 3 calls, but a one-shot CLI never accumulated them.
     const after = await listAgents(db);
     assert.strictEqual(after.length, 0);
   });
@@ -341,6 +341,21 @@ describe('mailbox', () => {
     assert.strictEqual(messages[0].body, 'attention everyone');
   });
 
+  test('case-mismatched direct message still reaches the recipient inbox', async () => {
+    joinAgent(db, 'Alice', 'surface-1', 'workspace-1', process.ppid);
+    joinAgent(db, 'Bob', 'surface-2', 'workspace-1', process.ppid);
+
+    // Bob addresses 'alice' (wrong case); getAgent resolves it case-insensitively, so the
+    // send must store the canonical 'Alice' or the recipient's case-sensitive inbox query misses it.
+    const res = await sendMessage(db, 'Bob', 'alice', 'ping');
+    assert.strictEqual(res.delivered, true);
+
+    const inbox = getInbox(db, 'Alice');
+    assert.strictEqual(inbox.length, 1);
+    assert.strictEqual(inbox[0].body, 'ping');
+    assert.strictEqual(inbox[0].to_agent, 'Alice'); // canonical, not the 'alice' that was typed
+  });
+
   test('inbox excludes own messages', () => {
     joinAgent(db, 'Alice', 'surface-1', 'workspace-1', process.ppid);
 
@@ -461,6 +476,91 @@ describe('migration', () => {
       assert.strictEqual(agent.agent_type, 'cmux');
       assert.strictEqual(message.swarm_id, DEFAULT_SWARM_ID);
       assert.strictEqual(cursor.swarm_id, DEFAULT_SWARM_ID);
+    } finally {
+      migrated.close();
+      try { fs.unlinkSync(legacyPath); } catch {}
+      try { fs.unlinkSync(legacyPath + '-wal'); } catch {}
+      try { fs.unlinkSync(legacyPath + '-shm'); } catch {}
+    }
+  });
+
+  test('a leftover *_new table from a prior failed migration does not wedge migrate()', () => {
+    const legacyPath = path.join(os.tmpdir(), `swarm-wedge-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    const legacy = new SQLite(legacyPath);
+    legacy.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, description TEXT,
+        surface_id TEXT NOT NULL, workspace_id TEXT, ppid INTEGER NOT NULL,
+        joined_at TEXT NOT NULL, last_heartbeat TEXT NOT NULL
+      );
+      CREATE TABLE messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, from_agent TEXT NOT NULL, to_agent TEXT,
+        body TEXT NOT NULL, delivered INTEGER NOT NULL DEFAULT 0, created_at TEXT NOT NULL
+      );
+      CREATE TABLE inbox_cursors (
+        agent_name TEXT PRIMARY KEY, last_read_id INTEGER NOT NULL DEFAULT 0
+      );
+      -- Simulate a half-built scratch table left behind by an interrupted/failed prior
+      -- migration. Pre-fix, the unguarded CREATE TABLE agents_new would throw
+      -- "table agents_new already exists" on every subsequent run, wedging the whole CLI.
+      CREATE TABLE agents_new (id TEXT PRIMARY KEY, leftover TEXT);
+    `);
+    const now = new Date().toISOString();
+    legacy.prepare(`INSERT INTO agents (id, name, description, surface_id, workspace_id, ppid, joined_at, last_heartbeat)
+      VALUES ('a', 'Alice', 'x', 's1', 'w1', 1, ?, ?)`).run(now, now);
+    legacy.close();
+
+    const migrated = getDbAt(legacyPath); // must not throw
+    try {
+      const cols = (migrated.prepare('PRAGMA table_info(agents)').all() as any[]).map(c => c.name);
+      assert.ok(cols.includes('swarm_id'), 'agents migrated to the multi-swarm schema');
+      const agent = migrated.prepare('SELECT * FROM agents WHERE name = ?').get('Alice') as any;
+      assert.strictEqual(agent.swarm_id, DEFAULT_SWARM_ID);
+      const leftover = migrated.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='agents_new'").get();
+      assert.strictEqual(leftover, undefined, 'scratch agents_new table is cleaned up');
+    } finally {
+      migrated.close();
+      try { fs.unlinkSync(legacyPath); } catch {}
+      try { fs.unlinkSync(legacyPath + '-wal'); } catch {}
+      try { fs.unlinkSync(legacyPath + '-shm'); } catch {}
+    }
+  });
+
+  test('migration de-duplicates case-variant names the new NOCASE unique would reject', () => {
+    const legacyPath = path.join(os.tmpdir(), `swarm-nocase-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    const legacy = new SQLite(legacyPath);
+    legacy.exec(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE, description TEXT,
+        surface_id TEXT NOT NULL, workspace_id TEXT, ppid INTEGER NOT NULL,
+        joined_at TEXT NOT NULL, last_heartbeat TEXT NOT NULL
+      );
+      CREATE TABLE messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, from_agent TEXT NOT NULL, to_agent TEXT,
+        body TEXT NOT NULL, delivered INTEGER NOT NULL DEFAULT 0, created_at TEXT NOT NULL
+      );
+      CREATE TABLE inbox_cursors (
+        agent_name TEXT PRIMARY KEY, last_read_id INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+    const older = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const newer = new Date().toISOString();
+    // The legacy binary UNIQUE allows 'Bob' and 'bob'; the new schema's NOCASE unique does not.
+    legacy.prepare(`INSERT INTO agents (id, name, description, surface_id, workspace_id, ppid, joined_at, last_heartbeat)
+      VALUES ('id-old', 'Bob', 'old', 's-old', 'w', 1, ?, ?)`).run(older, older);
+    legacy.prepare(`INSERT INTO agents (id, name, description, surface_id, workspace_id, ppid, joined_at, last_heartbeat)
+      VALUES ('id-new', 'bob', 'new', 's-new', 'w', 1, ?, ?)`).run(newer, newer);
+    legacy.prepare('INSERT INTO inbox_cursors (agent_name, last_read_id) VALUES (?, ?)').run('Bob', 5);
+    legacy.prepare('INSERT INTO inbox_cursors (agent_name, last_read_id) VALUES (?, ?)').run('bob', 9);
+    legacy.close();
+
+    const migrated = getDbAt(legacyPath); // must not throw on the NOCASE unique constraint
+    try {
+      const agents = migrated.prepare("SELECT * FROM agents WHERE name = 'bob' COLLATE NOCASE").all() as any[];
+      assert.strictEqual(agents.length, 1, 'one row survives per case-insensitive name');
+      assert.strictEqual(agents[0].id, 'id-new', 'the most-recently-active row is kept');
+      const cursor = migrated.prepare("SELECT * FROM inbox_cursors WHERE agent_name = 'bob' COLLATE NOCASE").get() as any;
+      assert.strictEqual(cursor.last_read_id, 9, 'the furthest-read cursor is kept');
     } finally {
       migrated.close();
       try { fs.unlinkSync(legacyPath); } catch {}


### PR DESCRIPTION
## Summary

Finalizes the multi-swarm / headless / per-surface-locking / lazy-reap work on this branch and fixes **8 bugs** — 3 reported by live swarm agents and 5 confirmed by an adversarial code review.

Built `dist/` is already running on the live local swarm and the fixes have been verified end-to-end by multiple agents (Forge, Gauge, Palette, Scribe).

## Bug fixes

| # | Fix | Source |
|---|-----|--------|
| 1 | **Headless re-join reclaim** — a session resume changes the controlling TTY, so the per-TTY identity marker stops resolving (`whoami` → "Not joined") while the roster entry persists; re-joining under Cmux then collided with the un-probeable headless entry. Re-join now reclaims the name instead of leaving an un-reclaimable orphan. | Palette/Gauge/Scribe |
| 2 | **broadcast no false-fail** — a failed push to a cmux/headless agent is now counted as queued-for-inbox (mirrors `sendMessage`); only a2a push failures are real misses. | Gauge |
| 3 | **rename-workspace Surface→Workspace id** — auto-resolves a Surface id to the agent's Workspace id and surfaces cmux's real stderr instead of a generic failure. | Gauge |
| 4 | **Crash-safe migration** — each legacy→multi-swarm rebuild runs in an atomic transaction with a leading `DROP TABLE IF EXISTS`, so a failed/interrupted rebuild can no longer leave a half-built `*_new` table that wedges every future `migrate()` (and thus every CLI command, incl. `swarm reset`). | review |
| 5 | **Case-mismatched DM no longer vanishes** — store the canonical `to_agent` (`getAgent` matches case-insensitively, but the inbox read is case-sensitive). | review |
| 6 | **Stale auto-reap** — heartbeat-gated double-probe replaces a module-level failure counter that never accumulated across the one-shot CLI, so auto-pruning never fired. (Cleared a 45-day-stale `Lead` ghost on first run.) | review |
| 7 | **AppleScript sanitize** — AppleScript delivery paths now strip newlines/tabs like the cmux socket path. | review |
| 8 | **Global `--swarm`/`-s` flag scoping** — no longer consumes tokens from message/title bodies; command-aware parsing extracted to `src/args.ts`. | review |

## Tests

- **+10 tests** (arg parsing, CLI reclaim + rename-workspace resolution, case-mismatch DM delivery, migration wedge-recovery).
- **50 total, all green**; `tsc` clean.

## Notes for review

- This commit captures the branch's accumulated working-tree state, so the diff includes both the in-progress multi-swarm/headless/locking feature work **and** the 8 fixes above.
- The stray `pnpm-lock.yaml` is intentionally **not** committed (this project is npm everywhere else).
- Deferred (low value, self-healing): persisting agent `host` for `removeHook` on dual-install hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
