### PR TITLE
Add redelivery sweep for push-failed messages (fixes idle-swarm stalls)

### DIFF
--- a/TODO-ARCHITECTURE.md
+++ b/TODO-ARCHITECTURE.md
@@ -1,0 +1,244 @@
+# Swarm — Architecture Critique & Improvement Roadmap
+
+> **Status:** Design backlog, not yet started. Captured 2026-07-03.
+> **Source:** An `/alloy` multi-model panel (codex + grok + claude, each reading the
+> real source tree read-only) plus the judge synthesis (Claude, with hands-on repo
+> context from ~10 bug fixes landed on `master` this session).
+>
+> This is the durable record of *why the current delivery model has a ceiling* and
+> *what to build instead*. Treat it as the north-star plan; open focused issues/PRs
+> off the ranked fix list in §5.
+
+---
+
+## TL;DR verdict
+
+- **The spine is sound.** SQLite (`~/.swarm/swarm.db`, WAL) + the mailbox model +
+  the A2A HTTP transport are the right foundation and should be kept.
+- **The delivery model is fundamentally limited, not merely rough.** "Deliver a
+  message by *typing it into another terminal*, and surface the inbox by *injecting
+  it into the next prompt*" is a **pull system wearing a push costume**. No daemon
+  means SQLite can't notify, so "push" can only ever be "inject on next prompt" —
+  and the terminal-keystroke hack exists purely to paper over that gap.
+- **The fix is a delivery-layer refactor, not a rewrite.** Invert to an explicit
+  durable-log **pull** model with acks, put a thin per-host daemon in charge of
+  delivery + backpressure, authenticate senders, and demote the keystroke transport
+  to an optional human-visible nudge.
+
+Cross-model agreement is a strong *recommendation*, not proof — but three
+independent models on the real code reached the same file-anchored conclusions, and
+they match what had to be patched by hand this session.
+
+---
+
+## 1. Deficiencies that are *fundamental* (a ceiling, not a rough edge)
+
+### 1a. Terminal-as-transport is UI automation cosplaying as IPC
+
+`sendToSurface` (`src/transport.ts:109`) chunks a message into 60-char slices,
+`cmux send`s each slice, then presses **Enter into another agent's interactive
+prompt line**. All three panelists independently flagged this as a house of cards:
+
+- **You are co-driving an input line you don't own.** If the recipient is
+  mid-generation, in a tool call, or showing a permission prompt, your keystrokes
+  interleave with its state. There is no framing, no "is the recipient ready?" — you
+  type and hope.
+- **The 60-char chunking (`CHUNK_SIZE = 60`, `src/transport.ts:49`, `:118`) exists
+  specifically to dodge "Claude Code paste-bracket detection."** You are
+  reverse-engineering a TUI's *undocumented* input heuristics. That is a **permanent
+  maintenance tax against a moving target** — any Claude Code input change can break
+  delivery silently. (grok's sharpest point.)
+- **`sanitize()` (`src/transport.ts:37`) flattens every `\n \r \t` to a space.** The
+  transport can therefore **only carry single-line prose** — no code block, no diff,
+  no JSON, no stack trace, without corruption. That alone disqualifies it as a
+  general agent-to-agent protocol. (claude's underrated catch.)
+- **The AppleScript/Warp path is a footgun, not a transport.** It clobbers the
+  user's clipboard and steals focus on every message, and the Warp focus fallback
+  lands on **the frontmost tab** (`src/applescript-transport.ts`) — i.e. it can type
+  a swarm message into whatever tab the human is actively looking at.
+
+### 1b. Prompt-as-mailbox has opposite-and-both-wrong delivery semantics
+
+The awareness hook (`hooks/swarm-awareness*.sh` → `swarm hook-context` →
+`printHookContext` → `getInbox`) reads the inbox with **`peek=false`, which advances
+the cursor** (`src/mailbox.ts`). Injecting the inbox into a prompt therefore
+*consumes* it:
+
+- **Headless path → at-most-once-with-loss.** If that turn is summarized/compacted,
+  or the model simply doesn't act on the "NEW MESSAGES" block, the message is **gone,
+  marked read, never retried.**
+- **Cmux path → at-least-once-with-dupes.** It types the message *and* leaves it
+  unread, so it gets re-injected next turn.
+- **Neither path is acknowledged.** There is no delivery receipt, no idempotency key,
+  no redelivery. The two transports have *opposite* failure modes and *both* are
+  wrong.
+
+**Root cause:** no daemon → SQLite can't push → "delivery" degrades to "inject on
+next prompt." Everything in §1a is scaffolding to hide this.
+
+---
+
+## 2. What's simply *absent* to be a real substrate
+
+Unanimous across the panel. None of these exist today:
+
+| Missing capability | Consequence today |
+|---|---|
+| Delivery guarantees | Silent loss (headless) or dupes (cmux) |
+| Acknowledgements | Sender never knows if a message landed or was acted on |
+| Idempotency | Redelivery would double-execute instructions |
+| Ordering integrity | Cursor advances by read-order, not a monotonic position (see §3) |
+| Backpressure / rate-limiting | Unbounded fan-out → org-wide rate-limit incident (§2b) |
+| Observability / audit | No log of what was delivered, to whom, acted-on or not |
+| Real authentication | `[SWARM from X]` is sender-chosen text → injection primitive (§2a) |
+| Supervision / lifecycle | No restart, no health, no dead-letter |
+| Typed messages | Everything is one sanitized single-line string |
+
+### 2a. Auth: `[SWARM from X]` is an open relay / prompt-injection primitive
+
+The `from` label is just a string the sender picks (`src/mailbox.ts:28`), and the
+awareness hook instructs **every agent to treat an inbound `[SWARM from ...]` line as
+a peer command.** So any process that can reach `swarm send` (or inject the wire
+format) can impersonate any agent and issue instructions. The entire safety story
+rests on the "trusted environment" assumption — which is doing enormous load-bearing
+work. (This is exactly why the "Bob" injection earlier this session was *possible*:
+the model **permits** it by design; it was not a bug.)
+
+### 2b. Backpressure: unbounded broadcast fan-out is the rate-limit root cause
+
+`broadcastMessage` (`src/mailbox.ts`) does `Promise.all` over **every** recipient,
+each injected message spawns an LLM turn, and the fan-out is unbounded. **This is
+almost certainly what caused the org-wide rate-limit incident this session** — and
+it's the one finding that reality has already proven, not just argued.
+
+---
+
+## 3. Judge addendum (context the panel lacked)
+
+- **The deepest issue none of them named outright: economics.** Prompt-as-mailbox
+  means *every delivered message = an LLM turn = money*. Coordination cost scales
+  with `message_volume × model_price`, with **zero governor**. The rate-limit blowup
+  wasn't just concurrency — the substrate's cost is **unbounded by construction**.
+  Any real fix must put a token/turn budget somewhere (the daemon in §5.2 is the
+  natural home).
+- **On the cursor-ordering bug** (all three flagged `ORDER BY created_at` vs.
+  cursoring on the max-by-position `id`): an adversarial verifier *empirically tested
+  this exact code earlier this session* — it is **dormant.** SQLite's stable sort
+  over the id-ordered index makes the last-returned row == max `id` in practice. So
+  it's theoretically real but **low priority**; the fix (order by `id`, advance
+  cursor via `Math.max(...ids)`) is trivial and worth doing **defensively** while the
+  code is open.
+- **~10 symptom fixes landed this session** (broadcast queued/failed counting,
+  case-mismatch DM loss via `COLLATE NOCASE`, migration wedge/NOCASE-dedup, reclaim
+  never auto-evicting a live agent, the `cleanupStale` strike-counter that could
+  never accumulate, `getSelf` identity fall-through, rename-workspace Surface→
+  Workspace id resolution). That **validates the panel's core thesis**: the rough
+  edges are endless because the *delivery model's spine* is wrong. You can patch
+  forever.
+
+---
+
+## 4. Fundamentally limited vs. rough — the answer to the key question
+
+| | Verdict |
+|---|---|
+| **Fundamentally limited (needs a different spine)** | `cmux send` / `osascript` keystroke delivery, and "push without a daemon" generally. You cannot harden "I'm typing into a human's prompt line, against undocumented TUI heuristics, single-line only, with a lock that gives up under load." |
+| **Rough but fixable (same spine)** | SQLite single file (great at this scale). The mailbox/cursor model (right idea — fix the cursor, make it non-consuming, add acks). **A2A — the only piece already built on a real protocol; it is the natural cross-machine spine and just needs acks + auth.** |
+
+### Where the panel split (salvageability)
+
+- **grok:** hard ceiling — doesn't scale, needs a different spine.
+- **claude:** keep the spine — this is a *delivery-layer* refactor, not a rewrite.
+- **codex (middle):** demote push to a *notification* path; move the authoritative
+  control plane to a durable queue/protocol.
+
+**Judge read:** claude is right on *tactics*, grok is right about the *keystroke
+transport specifically*. The honest synthesis is **codex's framing** — keep
+cmux/AppleScript **only** as an optional human-visible nudge, and make the
+authoritative channel a durable **pull-log with acks, owned by a thin daemon**. That
+is the line between "clever cross-terminal demo" and "reliable swarm of 5–10 agents
+working unbabysat."
+
+---
+
+## 5. Highest-leverage fixes (ranked, with effort)
+
+### 5.1 — Invert delivery to PULL  ·  ~1 day  ·  **do first**
+
+Make the durable log the source of truth. Agents poll their inbox (they already do,
+via the hook) and **ack explicitly**.
+
+- Make the hook **`peek` (never auto-consume)** — read without advancing the cursor.
+- Advance the cursor **only on an explicit ack**.
+- Kills, in one move: headless data-loss, cmux dupes, multiline corruption, and
+  focus-stealing (delivery no longer requires typing into a terminal).
+
+**Touch points:** `printHookContext`/`getInbox` (`peek=true`), a new `swarm ack`
+command + `acked`/cursor bookkeeping, hook script text.
+
+### 5.2 — Thin per-host daemon (or long-lived `swarm watch`)  ·  2–3 days
+
+A single long-lived process per host that **holds the DB, owns delivery, and enforces
+a concurrency cap + token bucket.**
+
+- Direct cure for the §2b rate-limit fan-out — the daemon is the **governor** for the
+  §3 economics problem (budget lives here).
+- Natural home for observability/audit and for turning "inject on next prompt" into
+  a real, rate-limited notification.
+
+### 5.3 — Per-recipient delivery rows + acks + idempotency + status  ·  1–2 days
+
+Add a per-recipient delivery table with a `status` column
+(`pending | delivered | acked | dead`), redelivery, and dead-lettering.
+
+- Gives real delivery guarantees + a complete audit trail.
+- Idempotency keys so a redelivery never double-executes.
+
+### 5.4 — Authenticate the sender  ·  ~1 day
+
+Issue a per-session token at `join`; require it on `send`.
+
+- Closes the §2a spoofing / prompt-injection primitive.
+- Keep the "trusted environment" default for local-only use, but make impersonation
+  require the token rather than a free-text `from` label.
+
+### 5.5 — Retire / quarantine the AppleScript/Warp keystroke transport  ·  hours
+
+Once inbox-pull (5.1) is primary, the keystroke path is net-negative (clipboard
+clobber, focus theft, frontmost-tab footgun, single-line-only). Demote it to an
+**optional human-visible nudge** or remove it.
+
+### 5.x — Defensive quick win (independent of the above)
+
+Fix the cursor ordering (§3) even though it's dormant: order by `id`, advance via
+`Math.max(...ids)` instead of `created_at`. Trivial, do it while the file is open.
+
+---
+
+## 6. What to keep (explicitly)
+
+- **SQLite + WAL** — correct choice at this scale; do not replace with a server DB.
+- **The mailbox/cursor concept** — keep it; just make it non-consuming + acked.
+- **A2A HTTP transport** — the only real-protocol piece; make it the cross-machine
+  spine (it needs acks + auth, not replacement).
+- **Identity resolution** (`getSelf` waterfall) — fine as-is after this session's
+  fall-through fix.
+
+---
+
+## 7. Raw panel output
+
+The full run — per-panelist `result.md` files (codex / grok / claude) plus the
+judge's `judge.json` — is preserved at:
+
+```
+~/.local/state/alloy/runs/20260628T144527Z-badd36/
+```
+
+Unique per-panelist insights worth re-reading there:
+- **claude:** `sanitize()` single-line-only limitation; AppleScript frontmost-tab
+  fallback footgun.
+- **codex:** broadcast `to_agent = NULL` lets a *newly joined* agent read historical
+  broadcasts (backfill leak).
+- **grok:** the 60-char chunking is a deliberate dodge of Claude Code's paste-bracket
+  detection (fragile by design).

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
   updateWorkspace,
 } from './registry.js';
 import { sendMessage, broadcastMessage, getInbox } from './mailbox.js';
+import { redeliverPending, runRedeliverWorker, spawnRedeliverWorker, hasPendingRedeliveries } from './redeliver.js';
 import { readScreen, identify, spawnSurfaceInWorkspace, spawnWorkspace, renameTab, moveSurface, listWorkspaces, renameWorkspace, sendToSurface, sleep } from './transport.js';
 import { installHook, removeHook, detectHost } from './hooks.js';
 import { registerSurface, removeSurface, loadSurface as loadSurfaceForHook } from './applescript-transport.js';
@@ -147,6 +148,7 @@ Communication:
   swarm send <agent> <message>                     Send message within the current swarm
   swarm broadcast <message>                        Send to all agents in the current swarm
   swarm inbox [--peek]                             Read pending messages
+  swarm redeliver [--dry-run]                      Re-push queued messages recipients haven't seen
 
 Status:
   swarm members                                    List agents in the current swarm
@@ -272,6 +274,11 @@ function printHookContext(): void {
   console.log(`You are "${self.name}" in swarm "${swarm.name}". Active agents: ${members || '(none)'}.
 Commands: swarm send <agent> "<msg>" | broadcast "<msg>" | inbox | members | status --set "<desc>"${readCommand}
 When you see [SWARM from <name>]: treat it as a message from another agent and respond.${inboxSection}`);
+
+  // Opportunistic recovery: if some OTHER agent has a fresh, unseen, push-failed
+  // message, kick a detached retry worker. One indexed SELECT when idle, so this
+  // adds no meaningful latency to the prompt hook.
+  if (hasPendingRedeliveries(db)) spawnRedeliverWorker();
 }
 
 async function main() {
@@ -487,6 +494,9 @@ async function main() {
         }
         const result = await sendMessage(db, self.swarm_id, self.name, targetName, message);
         console.log(result.message);
+        // Push failed → the recipient may be idle with no upcoming turn to poll
+        // the inbox. A detached worker retries the push on a backoff schedule.
+        if (result.queued) spawnRedeliverWorker();
         break;
       }
 
@@ -503,6 +513,9 @@ async function main() {
         if (result.queued > 0) line += ` (${result.queued} via inbox)`;
         if (result.failed > 0) line += `, ${result.failed} failed`;
         console.log(line);
+        // Note: broadcast rows (to_agent NULL) are not retried per-recipient —
+        // but a direct-message backlog may exist; sweep it while we're here.
+        if (result.queued > 0 && hasPendingRedeliveries(db)) spawnRedeliverWorker();
         break;
       }
 
@@ -519,6 +532,7 @@ async function main() {
           }
           console.log(`\n${messages.length} message(s)${peek ? ' (peek mode, not marked as read)' : ''}`);
         }
+        if (hasPendingRedeliveries(db)) spawnRedeliverWorker();
         break;
       }
 
@@ -932,6 +946,23 @@ async function main() {
           db.prepare('DELETE FROM messages WHERE swarm_id = ?').run(swarm.id);
           db.prepare('DELETE FROM inbox_cursors WHERE swarm_id = ?').run(swarm.id);
           console.log(`Swarm "${swarm.name}" reset. Cleared ${agents.length} agent(s) and its messages.`);
+        }
+        break;
+      }
+
+      case 'redeliver': {
+        const db = getDb();
+        if (hasFlag('--worker')) {
+          // Detached background retry loop (spawned on push failure). Exits when drained.
+          await runRedeliverWorker(db);
+          break;
+        }
+        const dryRun = hasFlag('--dry-run');
+        const result = await redeliverPending(db, { dryRun });
+        if (dryRun) {
+          console.log(`${result.eligible} message(s) eligible for redelivery (dry run, nothing pushed).`);
+        } else {
+          console.log(`Redelivered ${result.redelivered}/${result.eligible} pending message(s).`);
         }
         break;
       }

--- a/src/mailbox.ts
+++ b/src/mailbox.ts
@@ -18,10 +18,10 @@ export async function sendMessage(
   fromName: string,
   toName: string,
   body: string
-): Promise<{ delivered: boolean; message: string }> {
+): Promise<{ delivered: boolean; queued: boolean; message: string }> {
   const target = getAgent(db, swarmId, toName);
   if (!target) {
-    return { delivered: false, message: `Agent "${toName}" not found. Run 'swarm members' to see active agents.` };
+    return { delivered: false, queued: false, message: `Agent "${toName}" not found. Run 'swarm members' to see active agents.` };
   }
 
   const now = new Date().toISOString();
@@ -40,15 +40,17 @@ export async function sendMessage(
   const deliveryResult = await deliverToAgent(target, formatted);
   if (deliveryResult.delivered) {
     db.prepare('UPDATE messages SET delivered = 1 WHERE id = ?').run(msgId);
-    return { delivered: true, message: `Message sent to ${toName}` };
+    return { delivered: true, queued: false, message: `Message sent to ${toName}` };
   } else {
     // A2A agents can't read the local swarm inbox, so don't claim it was saved there
     if (target.agent_type === 'a2a') {
-      return { delivered: false, message: `Failed to deliver to ${toName}: ${deliveryResult.error || 'endpoint unreachable'}` };
+      return { delivered: false, queued: false, message: `Failed to deliver to ${toName}: ${deliveryResult.error || 'endpoint unreachable'}` };
     }
     // For Cmux and headless agents: push failed but message is in the DB.
-    // The recipient will pick it up via `swarm inbox`.
-    return { delivered: true, message: `Message sent to ${toName} (queued for inbox)` };
+    // The recipient will pick it up via `swarm inbox`, and the caller should
+    // spawn a redeliver worker so an idle recipient isn't stuck waiting for
+    // a turn that never comes (see redeliver.ts).
+    return { delivered: true, queued: true, message: `Message sent to ${toName} (queued for inbox)` };
   }
 }
 

--- a/src/redeliver.ts
+++ b/src/redeliver.ts
@@ -1,0 +1,177 @@
+import type Database from 'better-sqlite3';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { deliverToAgent } from './transport-router.js';
+import { getAgent } from './registry.js';
+import type { Message } from './mailbox.js';
+
+// A queued (push-failed) message is only worth re-pushing while the conversation
+// that produced it is still live. Past this window the work has moved on — the
+// message stays inbox-readable (cursor-based) but is never re-pushed, so a sweep
+// can't resurface stale context into a busy agent's prompt.
+export const REDELIVER_WINDOW_MS = 30 * 60 * 1000;
+
+export interface RedeliverResult {
+  eligible: number;
+  redelivered: number;
+  attempted: number;
+}
+
+type DeliverFn = typeof deliverToAgent;
+
+interface RedeliverOptions {
+  dryRun?: boolean;
+  deliver?: DeliverFn; // injectable for tests — never push at real surfaces from a test
+}
+
+/**
+ * Re-push messages whose original push failed ("queued for inbox") but that the
+ * recipient has provably NOT seen yet. Eligibility is deliberately strict:
+ *   - delivered = 0 (the push failed; inbox pickup was the fallback)
+ *   - direct messages only (broadcast rows share one global delivered bit,
+ *     so per-recipient redelivery state doesn't exist for them)
+ *   - recipient's inbox cursor has NOT passed the message (cursor-passed means
+ *     the hook/inbox already surfaced it — re-pushing would duplicate)
+ *   - younger than REDELIVER_WINDOW_MS (never resurface resolved work)
+ *   - recipient is not a2a (a failed a2a send was reported to the sender as a
+ *     real failure; the sender may have already re-sent — re-pushing risks dupes)
+ *
+ * Concurrency-safe: each message is claimed with an atomic
+ * `UPDATE ... WHERE delivered = 0` before pushing and reverted on push failure,
+ * so overlapping sweeps (hook + worker) can't double-deliver.
+ */
+export async function redeliverPending(
+  db: Database.Database,
+  options: RedeliverOptions = {}
+): Promise<RedeliverResult> {
+  const deliver = options.deliver ?? deliverToAgent;
+  const cutoff = new Date(Date.now() - REDELIVER_WINDOW_MS).toISOString();
+
+  const eligible = db.prepare(`
+    SELECT m.* FROM messages m
+    JOIN agents a
+      ON a.swarm_id = m.swarm_id AND a.name = m.to_agent COLLATE NOCASE
+    LEFT JOIN inbox_cursors c
+      ON c.swarm_id = m.swarm_id AND c.agent_name = m.to_agent COLLATE NOCASE
+    WHERE m.delivered = 0
+      AND m.to_agent IS NOT NULL
+      AND a.agent_type != 'a2a'
+      AND m.id > COALESCE(c.last_read_id, 0)
+      AND m.created_at > ?
+    ORDER BY m.id ASC
+  `).all(cutoff) as Message[];
+
+  const result: RedeliverResult = { eligible: eligible.length, redelivered: 0, attempted: 0 };
+  if (options.dryRun) return result;
+
+  const claim = db.prepare('UPDATE messages SET delivered = 1 WHERE id = ? AND delivered = 0');
+  const revert = db.prepare('UPDATE messages SET delivered = 0 WHERE id = ?');
+
+  for (const msg of eligible) {
+    // Atomic claim — a concurrent sweep that got here first wins, we skip.
+    if (claim.run(msg.id).changes === 0) continue;
+
+    const target = getAgent(db, msg.swarm_id, msg.to_agent!);
+    if (!target) {
+      // Recipient left between the SELECT and now — leave it claimed (nothing to push at).
+      continue;
+    }
+
+    result.attempted++;
+    const formatted = `[SWARM from ${msg.from_agent}]: ${msg.body}`;
+    try {
+      const delivery = await deliver(target, formatted);
+      if (delivery.delivered) {
+        result.redelivered++;
+      } else {
+        revert.run(msg.id); // stays queued for the next sweep (until it ages out)
+      }
+    } catch {
+      revert.run(msg.id);
+    }
+  }
+
+  return result;
+}
+
+// --- Detached retry worker -------------------------------------------------
+//
+// The sweep only runs when *some* swarm CLI invocation happens — but the exact
+// failure mode observed in the field is a fully idle swarm: a push fails, every
+// agent is waiting on that message, and nobody invokes anything for an hour.
+// So on a push failure the sender's CLI spawns ONE short-lived detached worker
+// that retries on a backoff schedule and exits as soon as the queue drains
+// (or after the last delay, when remaining messages are near the age-out window).
+
+const WORKER_DELAYS_SEC = [0, 30, 60, 120, 300];
+const WORKER_LOCK = path.join(os.homedir(), '.swarm', 'locks', 'redeliver-worker.lock');
+const WORKER_LOCK_STALE_MS = 10 * 60 * 1000;
+
+function tryAcquireWorkerLock(): boolean {
+  fs.mkdirSync(path.dirname(WORKER_LOCK), { recursive: true });
+  try {
+    fs.mkdirSync(WORKER_LOCK);
+  } catch {
+    try {
+      const stat = fs.statSync(WORKER_LOCK);
+      if (Date.now() - stat.mtimeMs <= WORKER_LOCK_STALE_MS) return false; // live worker
+      fs.rmSync(WORKER_LOCK, { recursive: true, force: true });
+      fs.mkdirSync(WORKER_LOCK);
+    } catch {
+      return false;
+    }
+  }
+  try { fs.writeFileSync(path.join(WORKER_LOCK, 'pid'), String(process.pid)); } catch {}
+  return true;
+}
+
+function releaseWorkerLock(): void {
+  try { fs.rmSync(WORKER_LOCK, { recursive: true, force: true }); } catch {}
+}
+
+export async function runRedeliverWorker(db: Database.Database): Promise<void> {
+  if (!tryAcquireWorkerLock()) return; // another worker is already on it
+  try {
+    for (const delaySec of WORKER_DELAYS_SEC) {
+      if (delaySec > 0) await new Promise(resolve => setTimeout(resolve, delaySec * 1000));
+      try { fs.utimesSync(WORKER_LOCK, new Date(), new Date()); } catch {}
+      const { eligible } = await redeliverPending(db);
+      if (eligible === 0) return; // drained (or everything aged out)
+    }
+  } finally {
+    releaseWorkerLock();
+  }
+}
+
+/** Fire-and-forget a detached retry worker (no-op if spawn fails). */
+export function spawnRedeliverWorker(): void {
+  try {
+    const child = spawn(
+      process.execPath,
+      [...process.execArgv, process.argv[1], 'redeliver', '--worker'],
+      { detached: true, stdio: 'ignore', env: process.env }
+    );
+    child.unref();
+  } catch {}
+}
+
+/** Cheap check used by hook-context/inbox: anything worth redelivering? */
+export function hasPendingRedeliveries(db: Database.Database): boolean {
+  const cutoff = new Date(Date.now() - REDELIVER_WINDOW_MS).toISOString();
+  const row = db.prepare(`
+    SELECT m.id FROM messages m
+    JOIN agents a
+      ON a.swarm_id = m.swarm_id AND a.name = m.to_agent COLLATE NOCASE
+    LEFT JOIN inbox_cursors c
+      ON c.swarm_id = m.swarm_id AND c.agent_name = m.to_agent COLLATE NOCASE
+    WHERE m.delivered = 0
+      AND m.to_agent IS NOT NULL
+      AND a.agent_type != 'a2a'
+      AND m.id > COALESCE(c.last_read_id, 0)
+      AND m.created_at > ?
+    LIMIT 1
+  `).get(cutoff);
+  return row !== undefined;
+}

--- a/tests/redeliver.test.ts
+++ b/tests/redeliver.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, beforeEach, after } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type Database from 'better-sqlite3';
+import { getDbAt } from '../src/db.js';
+import { redeliverPending, hasPendingRedeliveries, REDELIVER_WINDOW_MS } from '../src/redeliver.js';
+
+// Unit tests for the redelivery sweep. Delivery is stubbed — these tests must
+// NEVER push at a real cmux surface (the live swarm may be mid-session).
+
+const SWARM = 'default';
+let dir: string;
+let db: Database.Database;
+
+function addAgent(name: string, type: 'cmux' | 'headless' | 'a2a' = 'cmux'): void {
+  const now = new Date().toISOString();
+  db.prepare(`
+    INSERT INTO agents (id, swarm_id, name, agent_type, surface_id, workspace_id, ppid, joined_at, last_heartbeat)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(`agent-${name}`, SWARM, name, type, `surf-${name}`, `ws-${name}`, 0, now, now);
+}
+
+function addMessage(opts: {
+  from: string; to: string | null; delivered?: number; ageMs?: number; body?: string;
+}): number {
+  const createdAt = new Date(Date.now() - (opts.ageMs ?? 0)).toISOString();
+  const result = db.prepare(
+    'INSERT INTO messages (swarm_id, from_agent, to_agent, body, delivered, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run(SWARM, opts.from, opts.to, opts.body ?? 'hello', opts.delivered ?? 0, createdAt);
+  return Number(result.lastInsertRowid);
+}
+
+function setCursor(agent: string, lastReadId: number): void {
+  db.prepare('INSERT OR REPLACE INTO inbox_cursors (swarm_id, agent_name, last_read_id) VALUES (?, ?, ?)')
+    .run(SWARM, agent, lastReadId);
+}
+
+function deliveredFlag(id: number): number {
+  return (db.prepare('SELECT delivered FROM messages WHERE id = ?').get(id) as { delivered: number }).delivered;
+}
+
+const deliverOk = async () => ({ delivered: true });
+const deliverFail = async () => ({ delivered: false, error: 'surface gone' });
+
+describe('redeliverPending', () => {
+  beforeEach(() => {
+    if (db) db.close();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = mkdtempSync(join(tmpdir(), 'swarm-redeliver-'));
+    db = getDbAt(join(dir, 'swarm.db'));
+    addAgent('Alice');
+    addAgent('Bob');
+  });
+
+  after(() => {
+    if (db) db.close();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('re-pushes a fresh, unseen, push-failed direct message and marks it delivered', async () => {
+    const id = addMessage({ from: 'Alice', to: 'Bob' });
+    const pushed: string[] = [];
+    const result = await redeliverPending(db, {
+      deliver: async (_agent, text) => { pushed.push(text); return { delivered: true }; },
+    });
+    assert.deepStrictEqual(result, { eligible: 1, redelivered: 1, attempted: 1 });
+    assert.strictEqual(deliveredFlag(id), 1);
+    assert.match(pushed[0], /^\[SWARM from Alice\]: hello$/);
+  });
+
+  test('skips messages the recipient cursor has already passed (already seen via hook)', async () => {
+    const id = addMessage({ from: 'Alice', to: 'Bob' });
+    setCursor('Bob', id); // Bob's hook consumed it — re-pushing would duplicate
+    const result = await redeliverPending(db, { deliver: deliverOk });
+    assert.strictEqual(result.eligible, 0);
+    assert.strictEqual(deliveredFlag(id), 0); // untouched
+  });
+
+  test('skips stale messages older than the redelivery window', async () => {
+    addMessage({ from: 'Alice', to: 'Bob', ageMs: REDELIVER_WINDOW_MS + 60_000 });
+    const result = await redeliverPending(db, { deliver: deliverOk });
+    assert.strictEqual(result.eligible, 0);
+  });
+
+  test('skips broadcast rows, already-delivered messages, and a2a recipients', async () => {
+    addAgent('Remote', 'a2a');
+    addMessage({ from: 'Alice', to: null });                 // broadcast
+    addMessage({ from: 'Alice', to: 'Bob', delivered: 1 });  // push already succeeded
+    addMessage({ from: 'Alice', to: 'Remote' });             // a2a — sender was told it failed
+    const result = await redeliverPending(db, { deliver: deliverOk });
+    assert.strictEqual(result.eligible, 0);
+  });
+
+  test('cursor guard matches case-insensitively', async () => {
+    const id = addMessage({ from: 'Alice', to: 'Bob' });
+    setCursor('bob', id); // cursor stored with different casing must still count as seen
+    const result = await redeliverPending(db, { deliver: deliverOk });
+    assert.strictEqual(result.eligible, 0);
+  });
+
+  test('reverts the claim when the push fails, so the next sweep can retry', async () => {
+    const id = addMessage({ from: 'Alice', to: 'Bob' });
+    const r1 = await redeliverPending(db, { deliver: deliverFail });
+    assert.deepStrictEqual(r1, { eligible: 1, redelivered: 0, attempted: 1 });
+    assert.strictEqual(deliveredFlag(id), 0); // reverted — still queued
+
+    const r2 = await redeliverPending(db, { deliver: deliverOk });
+    assert.strictEqual(r2.redelivered, 1);
+    assert.strictEqual(deliveredFlag(id), 1);
+  });
+
+  test('reverts the claim when the deliver fn throws', async () => {
+    const id = addMessage({ from: 'Alice', to: 'Bob' });
+    const result = await redeliverPending(db, {
+      deliver: async () => { throw new Error('boom'); },
+    });
+    assert.strictEqual(result.redelivered, 0);
+    assert.strictEqual(deliveredFlag(id), 0);
+  });
+
+  test('dry run reports eligibility without pushing or mutating anything', async () => {
+    const id = addMessage({ from: 'Alice', to: 'Bob' });
+    let pushes = 0;
+    const result = await redeliverPending(db, {
+      dryRun: true,
+      deliver: async () => { pushes++; return { delivered: true }; },
+    });
+    assert.strictEqual(result.eligible, 1);
+    assert.strictEqual(result.attempted, 0);
+    assert.strictEqual(pushes, 0);
+    assert.strictEqual(deliveredFlag(id), 0);
+  });
+
+  test('a concurrent claim wins — the second sweep skips without double-delivering', async () => {
+    const id = addMessage({ from: 'Alice', to: 'Bob' });
+    const result = await redeliverPending(db, {
+      // Simulate a racing worker that claims the row before our push starts.
+      deliver: async () => {
+        db.prepare('UPDATE messages SET delivered = 1 WHERE id = ?').run(id);
+        return { delivered: true };
+      },
+    });
+    // Our sweep claimed it first (claim is the atomic gate), so it delivers once.
+    assert.strictEqual(result.redelivered, 1);
+
+    // And a follow-up sweep finds nothing — no second push.
+    const r2 = await redeliverPending(db, { deliver: deliverOk });
+    assert.strictEqual(r2.eligible, 0);
+  });
+
+  test('hasPendingRedeliveries mirrors eligibility', async () => {
+    assert.strictEqual(hasPendingRedeliveries(db), false);
+    const id = addMessage({ from: 'Alice', to: 'Bob' });
+    assert.strictEqual(hasPendingRedeliveries(db), true);
+    setCursor('Bob', id);
+    assert.strictEqual(hasPendingRedeliveries(db), false);
+  });
+});


### PR DESCRIPTION
## Problem

A failed cmux push falls back to *"queued for inbox"* — but inbox pickup requires the recipient to get a turn, and an idle agent never gets one. Observed in the field today: message 3415 (a "fixed, your move" handoff) failed to push at 18:02, the recipient sat idle, and the **entire swarm stalled for 84 minutes** until an unrelated prompt woke it.

## Fix

**`swarm redeliver`** — a sweep that re-pushes queued direct messages, with strict guards so it can never spam or resurface resolved work:

- recipient's inbox **cursor must not have passed** the message (cursor-passed = already surfaced via hook; re-pushing would duplicate)
- **younger than 30 min** (stale work has moved on; stays inbox-readable, never re-pushed)
- **direct messages only** (broadcast rows share one global delivered bit)
- **not a2a** (those failures were reported to the sender as failures)
- **claim-then-push-else-revert** (`UPDATE … WHERE delivered = 0`) makes overlapping sweeps double-delivery safe

**Detached retry worker** — on a queued push, the sender's CLI spawns one short-lived worker (retries at 0/30/60/120/300s, mkdir-lock singleton, exits when drained). This is what actually fixes the idle-swarm case: no daemon, but recovery no longer depends on someone else invoking the CLI. `hook-context`/`inbox` also kick the worker if a backlog exists (one indexed SELECT when idle).

## Validation

- 74/74 tests green (10 new: all guards, claim atomicity, revert-on-failure, dry-run purity, race behavior)
- Live-DB `--dry-run`: 0 eligible (current backlog is all cursor-passed/stale) → deploying is a no-op for the active session
- The cursor guard was validated against live production state: a requeued message whose recipient had already consumed it via hook was correctly refused

Stopgap for `TODO-ARCHITECTURE.md` §5.1–5.2 (pull+ack + daemon), which is the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UE8Z8CKeYfaew9u1CrqbL