### PR TITLE
Ride out cmux broken-pipe under load; don't prune busy agents; tune worker

### DIFF
--- a/src/redeliver.ts
+++ b/src/redeliver.ts
@@ -105,7 +105,12 @@ export async function redeliverPending(
 // that retries on a backoff schedule and exits as soon as the queue drains
 // (or after the last delay, when remaining messages are near the age-out window).
 
-const WORKER_DELAYS_SEC = [0, 30, 60, 120, 300];
+// Tight early retries catch the recipient's first idle window fast (once a busy
+// surface stops throwing broken pipe, the push lands); the long tail keeps trying
+// for a recipient that stays busy or goes idle without taking another turn. Total
+// span ~17 min. Active recipients recover sooner via their own inbox hook; this
+// worker is the safety net for the idle case that the hook can't cover.
+const WORKER_DELAYS_SEC = [0, 3, 7, 15, 30, 60, 120, 240, 480];
 const WORKER_LOCK = path.join(os.homedir(), '.swarm', 'locks', 'redeliver-worker.lock');
 const WORKER_LOCK_STALE_MS = 10 * 60 * 1000;
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -48,6 +48,27 @@ export function sanitize(text: string): string {
 
 const CHUNK_SIZE = 60;
 const STDIO_OPTS: { stdio: ['pipe', 'pipe', 'pipe'] } = { stdio: ['pipe', 'pipe', 'pipe'] };
+const MAX_SEND_ATTEMPTS = 5;
+const SEND_BACKOFF_BASE_S = 0.3;
+
+// A cmux send/read can fail two ways: the surface is genuinely gone, or the cmux
+// server dropped the connection under load ("Broken pipe", errno 32 / EPIPE /
+// connection reset). The latter is transient — the surface is alive, just busy —
+// and should be retried rather than treated as a dead surface (which would let
+// cleanupStale prune a live-but-busy agent).
+export function isTransientCmuxError(err: any): boolean {
+  const haystack = `${err?.stderr?.toString() ?? ''} ${err?.message ?? ''} ${err?.code ?? ''}`.toLowerCase();
+  return (
+    haystack.includes('broken pipe') ||
+    haystack.includes('errno 32') ||
+    haystack.includes('epipe') ||
+    haystack.includes('connection reset') ||
+    haystack.includes('econnreset') ||
+    haystack.includes('resource temporarily unavailable') ||
+    haystack.includes('eagain') ||
+    haystack.includes('socket')
+  );
+}
 
 export function sleep(seconds: number): void {
   execFileSync('sleep', [String(seconds)], STDIO_OPTS);
@@ -130,8 +151,17 @@ export function sendToSurface(surfaceId: string, text: string, workspaceId?: str
         execFileSync(cmux, ['send-key', ...wsArgs, '--surface', surfaceId, 'Enter'], STDIO_OPTS);
         return; // success
       } catch (err: any) {
-        if (attempt === 0) {
-          sleep(0.5); // brief pause before retry
+        // A "broken pipe"/socket-reset means the cmux server dropped the connection
+        // under load — the surface is alive but momentarily busy (recipient mid-turn).
+        // These are transient and worth several backoff retries; a genuine "surface
+        // not found" is terminal and should fail fast. (Field-measured: ~10% of sends
+        // to active agents hit broken pipe, roughly independent of message length.)
+        const transient = isTransientCmuxError(err);
+        const lastAttempt = attempt === MAX_SEND_ATTEMPTS - 1;
+        if (!lastAttempt && (transient || attempt === 0)) {
+          // Escalating backoff: 0.3, 0.6, 1.2, 2.4s. Rides out brief contention
+          // spikes without hammering a sustained-busy surface (the hook covers that).
+          sleep(SEND_BACKOFF_BASE_S * Math.pow(2, attempt));
           continue;
         }
         throw new SurfaceGoneError(surfaceId);
@@ -185,20 +215,27 @@ export function readScreen(surfaceId: string, lines?: number, workspaceId?: stri
   try {
     return execFileSync(cmux, args, STDIO_OPTS).toString();
   } catch (err: any) {
-    throw new SurfaceGoneError(surfaceId);
+    const gone = new SurfaceGoneError(surfaceId);
+    // Preserve the underlying cause so callers (isSurfaceAlive) can tell a genuinely
+    // gone surface from a transient "busy" broken pipe.
+    (gone as any).cause = err;
+    throw gone;
   }
 }
 
 export function isSurfaceAlive(surfaceId: string, workspaceId?: string | null): boolean {
-  // Retry once after a short delay to handle transient cmux socket errors
-  for (let attempt = 0; attempt < 2; attempt++) {
+  // Retry a few times with backoff. Critically: a TRANSIENT socket error (broken
+  // pipe from a busy surface) must NOT be read as "dead" — the surface is alive, just
+  // busy. Only a genuine non-transient failure (surface not found) counts as dead,
+  // so cleanupStale can never prune a live-but-busy agent.
+  for (let attempt = 0; attempt < 3; attempt++) {
     try {
       readScreen(surfaceId, 1, workspaceId);
       return true;
-    } catch {
-      if (attempt === 0) {
-        // Brief pause before retry — transient socket contention
-        execFileSync('sleep', ['0.5'], STDIO_OPTS);
+    } catch (err: any) {
+      if (isTransientCmuxError(err?.cause)) return true; // busy, not gone
+      if (attempt < 2) {
+        execFileSync('sleep', [String(0.3 * (attempt + 1))], STDIO_OPTS);
       }
     }
   }

--- a/tests/transport.test.ts
+++ b/tests/transport.test.ts
@@ -1,0 +1,49 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { isTransientCmuxError } from '../src/transport.js';
+
+// The transient/gone classification decides whether a failed cmux send is retried
+// (busy surface) or treated as a dead surface (which lets cleanupStale prune the
+// agent). Getting this wrong either drops messages or evicts live agents.
+describe('isTransientCmuxError', () => {
+  test('classifies the field-observed broken-pipe failure as transient', () => {
+    // Exact stderr captured from a live send to a busy agent (2026-07-06).
+    const err = { stderr: Buffer.from('Error: Failed to write to socket (Broken pipe, errno 32)') };
+    assert.strictEqual(isTransientCmuxError(err), true);
+  });
+
+  test('recognizes assorted transient socket signals', () => {
+    for (const s of [
+      'write EPIPE',
+      'Error: connection reset by peer',
+      'ECONNRESET',
+      'resource temporarily unavailable',
+      'EAGAIN',
+      'errno 32',
+      'Failed to write to socket',
+    ]) {
+      assert.strictEqual(isTransientCmuxError({ stderr: Buffer.from(s) }), true, s);
+    }
+  });
+
+  test('reads the signal from message or code, not just stderr', () => {
+    assert.strictEqual(isTransientCmuxError({ message: 'write EPIPE' }), true);
+    assert.strictEqual(isTransientCmuxError({ code: 'EPIPE' }), true);
+  });
+
+  test('classifies a genuinely-gone surface as NOT transient (fail fast)', () => {
+    const err = { stderr: Buffer.from('Error: Surface not found: 7C9F5A6A') };
+    assert.strictEqual(isTransientCmuxError(err), false);
+  });
+
+  test('does not treat an invalid-handle usage error as transient', () => {
+    const err = { stderr: Buffer.from('Error: Invalid workspace handle: FAKE (expected UUID)') };
+    assert.strictEqual(isTransientCmuxError(err), false);
+  });
+
+  test('handles null/undefined/empty without throwing', () => {
+    assert.strictEqual(isTransientCmuxError(null), false);
+    assert.strictEqual(isTransientCmuxError(undefined), false);
+    assert.strictEqual(isTransientCmuxError({}), false);
+  });
+});


### PR DESCRIPTION
Root cause of intermittent "stuck" messages (field-diagnosed 2026-07-06 by
instrumenting the real cmux stderr): `cmux send` fails with "Broken pipe,
errno 32" ~10% of the time when the recipient surface / cmux server is busy
(recipient mid-turn). Failure rate is roughly independent of message length,
so it's socket contention, not chunking. Messages were never lost — the
recipient's awareness hook sweeps them on its next turn — but the push kept
failing until then, which reads as "stuck."

Three fixes:

1. Classify broken-pipe / EPIPE / connection-reset as TRANSIENT (new
   isTransientCmuxError) vs a genuinely-gone surface. sendToSurface now
   retries transients up to 5x with escalating backoff (0.3/0.6/1.2/2.4s)
   instead of failing after 2 attempts 0.5s apart — riding out brief
   contention spikes that previously became false delivery failures.

2. isSurfaceAlive treats a transient error as ALIVE (busy != dead) — a
   sustained-busy surface throwing broken pipe on the liveness read can no
   longer be misread as dead and pruned by cleanupStale. readScreen now
   preserves the underlying cmux error as `.cause` so callers can classify.

3. Redeliver worker schedule tightened + extended (0/3/7/15/30/60/120/240/480s,
   ~17 min) so it catches the recipient's first idle window fast and keeps
   trying longer for a recipient that goes idle without taking another turn.
   Max inter-retry gap (8m) stays under the 10m worker-lock stale threshold,
   so a long run never breaks its own singleton lock.

Diagnostics used to find this (temporary send-debug/redeliver-debug logging)
are removed. 80 tests green (6 new covering the transient/gone classifier).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013UE8Z8CKeYfaew9u1CrqbL
