### PR TITLE
Cap keystroke push to one chunk (nudge long messages); fix retry regression

### DIFF
--- a/src/cmux-transport.ts
+++ b/src/cmux-transport.ts
@@ -1,19 +1,34 @@
 import { Transport, TransportAgent, TransportDeliveryResult } from './transport-interface.js';
 import { sendToSurface, SurfaceGoneError, isSurfaceAlive } from './transport.js';
 
+// A keystroke push is reliable only for a single short send. Typing a long,
+// multi-chunk message into a live Claude Code TUI silently drops chunks (the
+// send reports success but only a fragment lands) and, on retry, duplicates the
+// partial text — both observed in the field. So we cap the pushed payload to one
+// chunk: short messages push in full; long ones push a compact NUDGE, and the
+// awareness hook delivers the full body on the turn the nudge triggers (the hook
+// reads the inbox regardless of what was typed). This is the "demote push to a
+// notification" fix — the push wakes the recipient; the hook carries the content.
+export const PUSH_MAX_CHARS = 60;
+
+export function buildPushText(formattedText: string): string {
+  if (formattedText.length <= PUSH_MAX_CHARS) return formattedText;
+  const match = formattedText.match(/^\[SWARM from ([^\]]+)\]/);
+  const sender = (match ? match[1] : 'a peer').slice(0, 24);
+  const nudge = `[SWARM] new message from ${sender} — see inbox`;
+  // Defensive: keep the nudge itself within one chunk even for a long sender name.
+  return nudge.length <= PUSH_MAX_CHARS ? nudge : nudge.slice(0, PUSH_MAX_CHARS);
+}
+
 export class CmuxTransport implements Transport {
   async deliverMessage(agent: TransportAgent, formattedText: string): Promise<TransportDeliveryResult> {
-    // Cmux socket only. There used to be an AppleScript clipboard-paste fallback here,
-    // but it could not target a surface — it activated the cmux app and pasted into
-    // whatever tab was FOCUSED (its Cmd+N workspace switch only understood legacy
-    // "workspace:N" refs, never UUIDs), stole focus, clobbered the clipboard, and
-    // falsely reported delivered=true. Field-observed misrouting messages into the
-    // user's active tab (the "[SWARM from Bob]: ping" incident — the test suite's
-    // fake-surface sends fell back to it and pasted into the frontmost terminal).
-    // A socket failure is handled gracefully instead: the message stays queued in the
-    // DB (inbox/hook pickup) and the redeliver worker retries the socket path.
+    // Cmux socket only. There used to be an AppleScript clipboard-paste fallback
+    // here, but it pasted into whatever tab was FOCUSED and misrouted messages
+    // (the "[SWARM from Bob]" incident); it was removed. A socket failure now
+    // returns delivered=false: the message stays queued in the DB (inbox/hook
+    // pickup) and the redeliver worker retries the socket path.
     try {
-      sendToSurface(agent.surface_id, formattedText, agent.workspace_id);
+      sendToSurface(agent.surface_id, buildPushText(formattedText), agent.workspace_id);
       return { delivered: true };
     } catch (err) {
       if (!(err instanceof SurfaceGoneError)) throw err;

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -133,10 +133,18 @@ export function sendToSurface(surfaceId: string, text: string, workspaceId?: str
   const wsArgs = workspaceId ? ['--workspace', workspaceId] : [];
   const lockPath = acquireSurfaceLock(surfaceId);
   try {
-    // Retry once on failure to handle transient cmux errors
-    for (let attempt = 0; attempt < 2; attempt++) {
+    for (let attempt = 0; attempt < MAX_SEND_ATTEMPTS; attempt++) {
       try {
-        // Chunk long messages to avoid Claude Code paste-bracket detection
+        // Before a RETRY, clear the input line: a prior attempt may have typed
+        // part of the text before failing, and re-typing from the start would
+        // duplicate or garble it in the recipient's prompt buffer (field-observed
+        // "…STREAM…STREAM" duplication). ctrl+u clears the current line.
+        if (attempt > 0) {
+          try { execFileSync(cmux, ['send-key', ...wsArgs, '--surface', surfaceId, 'ctrl+u'], STDIO_OPTS); } catch {}
+        }
+        // Chunk long text to avoid Claude Code paste-bracket detection. (Message
+        // delivery caps payloads to a single chunk upstream — see cmux-transport's
+        // nudge — so multi-chunk sends here are spawn commands to fresh surfaces.)
         if (safe.length <= CHUNK_SIZE) {
           execFileSync(cmux, ['send', ...wsArgs, '--surface', surfaceId, safe], STDIO_OPTS);
         } else {

--- a/tests/transport.test.ts
+++ b/tests/transport.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import { isTransientCmuxError } from '../src/transport.js';
+import { buildPushText, PUSH_MAX_CHARS } from '../src/cmux-transport.js';
 
 // The transient/gone classification decides whether a failed cmux send is retried
 // (busy surface) or treated as a dead surface (which lets cleanupStale prune the
@@ -45,5 +46,40 @@ describe('isTransientCmuxError', () => {
     assert.strictEqual(isTransientCmuxError(null), false);
     assert.strictEqual(isTransientCmuxError(undefined), false);
     assert.strictEqual(isTransientCmuxError({}), false);
+  });
+});
+
+// The keystroke push must never exceed one chunk: multi-chunk sends to a busy
+// TUI silently drop/duplicate content (delivered=true but only a fragment lands).
+describe('buildPushText (single-chunk push, nudge for long messages)', () => {
+  test('passes a short message through in full', () => {
+    const short = '[SWARM from Atlas]: ping';
+    assert.strictEqual(buildPushText(short), short);
+  });
+
+  test('a message at the boundary is still sent in full', () => {
+    const msg = '[SWARM from A]: ' + 'x'.repeat(PUSH_MAX_CHARS - '[SWARM from A]: '.length);
+    assert.strictEqual(msg.length, PUSH_MAX_CHARS);
+    assert.strictEqual(buildPushText(msg), msg);
+  });
+
+  test('a long message collapses to a nudge naming the sender, within one chunk', () => {
+    const long = '[SWARM from Atlas]: ' + '🎯 DEEPSEEK BATTERY (dpl_BpGCa) — STREAM HANG '.repeat(20);
+    const push = buildPushText(long);
+    assert.ok(push.length <= PUSH_MAX_CHARS, `nudge too long: ${push.length}`);
+    assert.match(push, /Atlas/);
+    assert.match(push, /inbox/);
+  });
+
+  test('the nudge stays within one chunk even for an absurdly long sender name', () => {
+    const long = `[SWARM from ${'N'.repeat(200)}]: ` + 'body '.repeat(50);
+    const push = buildPushText(long);
+    assert.ok(push.length <= PUSH_MAX_CHARS, `nudge too long: ${push.length}`);
+  });
+
+  test('a long message with no parseable sender still nudges within one chunk', () => {
+    const push = buildPushText('x'.repeat(500));
+    assert.ok(push.length <= PUSH_MAX_CHARS);
+    assert.match(push, /inbox/);
   });
 });


### PR DESCRIPTION
Two field-observed defects, both from typing multi-chunk messages into a live
Claude Code TUI:

1. SILENT DROP: a long message is chunked into ~25 sends; a busy TUI drops
   chunks while cmux reports success (delivered=1) — only a fragment lands and
   the Enter never fires, so the hook doesn't fire either. The message sits
   truncated at the prompt (msg 4143/4180 in the field).

2. DUPLICATION + FALSE SUCCESS: PR #8's transient-retry re-typed the whole
   message from the start into a buffer still holding the previous attempt's
   partial text, producing "…STREAM…STREAM" duplication. Worse, the retry loop
   bound was left at `attempt < 2` while the logic referenced MAX_SEND_ATTEMPTS
   (5), so a double-transient-failure exited the loop WITHOUT throwing —
   falsely returning success while nothing was delivered.

Fixes:
- cmux-transport now caps the pushed payload to one chunk (buildPushText):
  short messages push in full; long ones push a compact "[SWARM] new message
  from <sender> — see inbox" nudge. The awareness hook delivers the full body
  on the turn the nudge triggers, so no content is lost and nothing is chunked
  into a busy TUI. This is the "demote push to a notification" fix from
  TODO-ARCHITECTURE.md — the push wakes the recipient; the hook carries content.
- sendToSurface: loop bound corrected to MAX_SEND_ATTEMPTS (kills the
  false-success path), and a ctrl+u clear-line is sent before each retry so a
  retry can't duplicate a prior attempt's partial text. Multi-chunk sends now
  only ever go to fresh spawn surfaces, not busy agents.

85 tests green (5 new: nudge stays within one chunk, names the sender, handles
absurd sender names and unparseable input).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013UE8Z8CKeYfaew9u1CrqbL
