### PR TITLE
Cross-machine A2A bridge: swarm serve, a2a identity, a2a redelivery, model-name policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Cross-terminal agent coordination CLI via Cmux and A2A protocol.
 
 Swarm supports these transport modes:
 
-- **Cmux agents** (Codex, Codex) register via `swarm join <name>`, which stores their Cmux surface ID in SQLite (`~/.swarm/swarm.db`). Messages are pushed via `cmux send` + `cmux send-key Enter`.
+- **Cmux agents** (Claude Code, Codex, Grok CLI) register via `swarm join <name>`, which stores their Cmux surface ID in SQLite (`~/.swarm/swarm.db`). Messages are pushed via `cmux send` + `cmux send-key Enter`.
 - **Warp agents** register as headless terminal agents with Warp surface metadata. `swarm spawn --terminal warp` opens a new Warp tab via `warp://action/new_tab`; push delivery is deferred, so messages queue for `swarm inbox`.
 - **A2A agents** (OpenClaw, Hermes, etc.) register via `swarm register-a2a <name> --endpoint <url>`. Messages are delivered via the A2A protocol over HTTP. This enables cross-user and cross-machine coordination.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Cross-terminal agent coordination CLI via Cmux and A2A protocol.
 
 Swarm supports two transport types:
 
-- **Cmux agents** (Claude Code, Codex) register via `swarm join <name>`, which stores their Cmux surface ID in SQLite (`~/.swarm/swarm.db`). Messages are pushed via `cmux send` + `cmux send-key Enter`.
+- **Cmux agents** (Claude Code, Codex, Grok CLI) register via `swarm join <name>`, which stores their Cmux surface ID in SQLite (`~/.swarm/swarm.db`). Messages are pushed via `cmux send` + `cmux send-key Enter`.
 - **A2A agents** (OpenClaw, Hermes, etc.) register via `swarm register-a2a <name> --endpoint <url>`. Messages are delivered via the A2A protocol over HTTP. This enables cross-user and cross-machine coordination.
 
 Stale agents are cleaned up by checking liveness (Cmux surface check or A2A agent card ping) combined with a 30-minute heartbeat threshold, and only after several consecutive failed liveness probes. Headless agents are never auto-pruned (they have no probeable surface).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Cross-terminal and cross-agent coordination for AI coding agents. Supports local agents running in [Cmux](https://cmux.dev) and remote agents via the [A2A (Agent-to-Agent) protocol](https://google.github.io/A2A/).
 
-Send messages between Claude Code sessions, OpenClaw, Hermes, and any A2A-compatible agent — monitor what other agents are working on and coordinate multi-agent workflows from the terminal. Swarm can run multiple independent project swarms at the same time, so each codebase can have its own Lead and agent set.
+Send messages between Claude Code, Codex, Grok CLI, OpenClaw, Hermes, and any A2A-compatible agent — monitor what other agents are working on and coordinate multi-agent workflows from the terminal. Swarm can run multiple independent project swarms at the same time, so each codebase can have its own Lead and agent set.
 
 ## How it works
 
@@ -24,7 +24,7 @@ Send messages between Claude Code sessions, OpenClaw, Hermes, and any A2A-compat
                                   └──────────────┘
 ```
 
-**Cmux agents** (Claude Code, Codex CLI) register with `swarm join` and receive messages pushed directly into their terminal via Cmux's native `send` command.
+**Cmux agents** (Claude Code, Codex CLI, Grok CLI) register with `swarm join` and receive messages pushed directly into their terminal via Cmux's native `send` command.
 
 **A2A agents** (OpenClaw, Hermes, or any agent with an A2A-compatible endpoint) register with `swarm register-a2a` and receive messages delivered over HTTP via the A2A protocol. This enables cross-user and cross-machine coordination.
 
@@ -35,7 +35,7 @@ Send messages between Claude Code sessions, OpenClaw, Hermes, and any A2A-compat
 - **macOS** (Cmux is macOS-only; A2A agents can run on any platform)
 - **[Cmux](https://cmux.dev)** installed and running (for local terminal agents)
 - **Node.js >= 20** (`node --version` to check)
-- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** and/or **[Codex CLI](https://github.com/openai/codex)** for Cmux agents
+- **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)**, **[Codex CLI](https://github.com/openai/codex)**, and/or **[Grok CLI](https://x.ai/cli)** for Cmux agents
 - Any A2A-compatible agent (e.g., OpenClaw, Hermes) for remote coordination
 
 ## Install
@@ -48,22 +48,23 @@ npm run build
 ./install.sh
 ```
 
-The install script auto-detects which agents you have installed (Claude Code, Codex CLI) and configures skills for each:
+The install script auto-detects which agents you have installed (Claude Code, Codex CLI, Grok CLI, Gemini) and configures skills for each:
 
 - **Claude Code**: installs `/swarm`, `/join-swarm`, `/leave-swarm`, `/reset-swarm` skills as symlinks + a `UserPromptSubmit` hook for persistent swarm awareness
 - **Codex CLI**: installs `swarm`, `join-swarm`, `leave-swarm`, `reset-swarm` skills into `~/.codex/skills` + durable coordination instructions at `~/.codex/swarm-instructions.md`
+- **Grok CLI**: installs the same skills as symlinks under `~/.grok/skills` + a global `UserPromptSubmit` hook at `~/.grok/hooks/swarm-awareness.json`
 
 The awareness hook automatically reminds joined agents of their swarm identity, active members, and available commands on every turn where the host supports hooks. Codex stores durable install instructions separately from session hints in `~/.codex/swarm-session.md`; the CLI resolves the actual current identity from the terminal/session marker.
 
 ### Verify
 
-Open a fresh Claude Code or Codex session in Cmux. In Claude Code, run:
+Open a fresh Claude Code, Codex, or Grok session in Cmux. In Claude Code or Grok, run:
 
 ```
 /join-swarm TestAgent --swarm test
 ```
 
-In Codex, invoke the `join-swarm` skill or ask Codex to use `join-swarm` with `TestAgent --swarm test`. You should see: `Joined swarm "test" as "TestAgent" ...`. Then clean up with `/leave-swarm` in Claude Code or the `leave-swarm` skill in Codex.
+In Codex, invoke the `join-swarm` skill or ask Codex to use `join-swarm` with `TestAgent --swarm test`. You should see: `Joined swarm "test" as "TestAgent" ...`. Then clean up with `/leave-swarm` (Claude/Grok) or the `leave-swarm` skill (Codex).
 
 ## Quick start
 
@@ -110,7 +111,7 @@ swarm create docs --root /Users/tom/Developer/docs-site
 | `/leave-swarm` | Leave the current swarm. |
 | `/reset-swarm` | Clear the current swarm's agents, messages, and inbox state. |
 
-Claude Code exposes these as slash commands. Codex loads them as skills from `~/.codex/skills`; invoke the matching skill name, for example `join-swarm`.
+Claude Code and Grok CLI expose these as slash commands (`/join-swarm`, etc.). Codex loads them as skills from `~/.codex/skills`; invoke the matching skill name, for example `join-swarm`.
 
 ## CLI Reference
 
@@ -147,7 +148,8 @@ Shared:
   swarm status [--set <desc>] [--agent <name>] Update or query status
 
 Spawning:
-  swarm spawn [--cwd <path>] [--autonomous]   Spawn Claude in a new Cmux tab
+  swarm spawn [--cwd <path>] [--autonomous]   Spawn Claude/Codex/Grok in a new tab
+    [--agent claude|codex|grok] [--name <n>]
                                               (auto-joins the swarm after boot)
 
 Workspace management:
@@ -220,13 +222,14 @@ swarm broadcast "status check — what's everyone working on?"
 
 ### Spawning new agents
 
-A lead agent can spin up new Claude Code or Codex sessions directly. By default, `swarm spawn` opens Warp tabs when run inside Warp and Cmux surfaces otherwise:
+A lead agent can spin up new Claude Code, Codex, or Grok sessions directly. By default, `swarm spawn` opens Warp tabs when run inside Warp and Cmux surfaces otherwise:
 ```bash
 swarm spawn --cwd /path/to/project --swarm ridge --autonomous
+swarm spawn --agent grok --name Brillo --cwd /path/to/project --swarm ridge
 swarm spawn --terminal warp --name DevA --cwd /path/to/project --swarm ridge
 ```
 
-In Cmux, this opens a new tab in the current workspace, launches the agent, and auto-sends `/join-swarm --swarm ridge` after boot. If `swarm spawn` is run outside a Cmux workspace, it falls back to creating a new workspace. In Warp, it opens a new tab via Warp's URL scheme; named Claude agents join before launch, and Codex agents receive join instructions as their initial prompt. The `--autonomous` flag enables `--dangerously-skip-permissions` for Claude and `--yolo` for Codex.
+In Cmux, this opens a new tab in the current workspace, launches the agent, and auto-sends `/join-swarm --swarm ridge` after boot (Claude). If `swarm spawn` is run outside a Cmux workspace, it falls back to creating a new workspace. In Warp, it opens a new tab via Warp's URL scheme; named Claude agents join before launch, and Codex/Grok agents receive join instructions as their initial prompt. The `--autonomous` flag enables `--dangerously-skip-permissions` for Claude, `--yolo` for Codex, and `--always-approve` for Grok.
 
 ### Organizing workspaces
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -27,7 +27,7 @@ Error: Could not locate the bindings file. Tried:
 
 ### Cause
 
-The swarm CLI uses native `better-sqlite3` via `bin/swarm` (`#!/usr/bin/env node`). The native module ships prebuilds keyed to specific node ABIs:
+`better-sqlite3` is a native addon keyed to a specific Node ABI. Agents on the same machine often have different `node` first on PATH (Homebrew Node 25 vs nvm Node 24), so `#!/usr/bin/env node` would load a mismatched binary.
 
 | Node version | NODE_MODULE_VERSION (ABI) |
 |---|---|
@@ -35,37 +35,45 @@ The swarm CLI uses native `better-sqlite3` via `bin/swarm` (`#!/usr/bin/env node
 | node 24.x | 137 |
 | node 25.x | 141 |
 
-`prebuild-install` (run automatically on `npm install` / `npm rebuild`) frequently fetches the wrong ABI's prebuild, and the `build/Release/better_sqlite3.node` binary ends up incompatible with the active node. Compiling from source on Darwin currently fails with a Python 3.14 expat symbol error (`_XML_SetAllocTrackerActivationThreshold`), so source-build isn't a reliable fallback.
+### Preferred fix — pin Node for swarm (machine-local)
 
-### Reliable fix — direct prebuild download
+`bin/swarm` is a bash launcher that prefers:
+
+1. `$SWARM_NODE` (absolute path to a node binary)
+2. `~/.swarm/node-path` (one line: absolute path — **not in the git repo**)
+3. first `node` on PATH
+
+Pin this host once (match the ABI of the installed prebuild; currently Node 24 / ABI 137):
 
 ```bash
-# 1. Get the active node ABI
+mkdir -p ~/.swarm
+echo '/Users/tom/.nvm/versions/node/v24.14.1/bin/node' > ~/.swarm/node-path
+swarm members   # should work even if Homebrew node 25 is first on PATH
+```
+
+### Auto-repair — official prebuild download
+
+If the active node still mismatches, `bin/swarm-entry.mjs` downloads the matching WiseLibs prebuild for the current ABI (does **not** run `npm rebuild`, which thrash-fetches the wrong ABI mid-session). One re-exec after download.
+
+Manual equivalent:
+
+```bash
 ABI=$(node -e "console.log(process.versions.modules)")  # e.g. "137"
-
-# 2. Get the installed better-sqlite3 version
 VERSION=$(node -p "require('/Users/tom/Developer/Ridge.io/swarm/node_modules/better-sqlite3/package.json').version")
-
-# 3. Download the matching prebuild
 cd /tmp
 curl -sL "https://github.com/WiseLibs/better-sqlite3/releases/download/v${VERSION}/better-sqlite3-v${VERSION}-node-v${ABI}-darwin-arm64.tar.gz" -o bsq.tgz
-
-# 4. Replace the broken build dir
 cd /Users/tom/Developer/Ridge.io/swarm/node_modules/better-sqlite3
 rm -rf build
 tar -xzf /tmp/bsq.tgz
-
-# 5. Verify
 swarm members
 ```
-
-Confirmed working on 2026-04-29 with `v12.9.0` + `v137` (node 24) + darwin-arm64.
 
 ### Anti-patterns to avoid
 
 - ❌ `npm install` / `npm rebuild` in the swarm dir during a live session — repeatedly deletes and re-fetches the wrong prebuild, breaking every connected agent's swarm CLI for minutes at a time.
 - ❌ `--build-from-source` — fails on Python 3.14 expat issue.
 - ❌ Pinning to an older `better-sqlite3` (e.g. 11.10.0) hoping a different prebuild — the same ABI mismatch logic applies.
+- ❌ Un-pinning `~/.swarm/node-path` while multiple agents share one install — each agent's PATH may thrash the single shared `.node` binary.
 
 ---
 
@@ -111,6 +119,45 @@ When cmux workspaces are closed, the agent rows persist in `~/.swarm/swarm.db`. 
 ```bash
 sqlite3 ~/.swarm/swarm.db \
   "DELETE FROM agents WHERE name IN ('Stale1','Stale2',...)"
+```
+
+---
+
+## Local reserved agent names (not in the git repo)
+
+Some machines keep OpenClaw / A2A identities that local Cmux agents must not claim.
+
+- Config file (machine-local): `~/.swarm/reserved-names` — one name per line, `#` comments OK
+- Or env: `SWARM_RESERVED_NAMES=Forge,Cooper` / `SWARM_RESERVED_NAMES_FILE=/path/to/file`
+
+`swarm join` rejects reserved names. The list is **never** committed to the swarm repo — each host maintains its own. A2A registration is not blocked (those names are intended for remote agents).
+
+---
+
+## Grok CLI: queue vs send-now (Enter)
+
+### Behavior
+
+Grok's TUI mid-turn input has two modes (footer: `Enter:send now` / `Ctrl+;:queue`):
+
+- **Single Enter after a push** — message is **queued** (does not interrupt the current turn). This is the default for `swarm send` / `swarm broadcast`.
+- **Double Enter** — force **send-now / interject**. Only used when the sender opts in.
+
+### Opt-in interject
+
+```bash
+swarm send Brillo "urgent: stop and review" --interject
+swarm broadcast "drop everything" --now
+```
+
+`--interject` / `--now` only changes delivery for agents with `host_agent = 'grok'` (second Enter). Claude/Codex still get one Enter.
+
+### Host tagging
+
+Join records `host_agent` via `detectHost()` (`GROK_AGENT` / `CMUX_AGENT_LAUNCH_KIND=grok`). Existing sessions refresh on whoami/inbox/status. Manual tag:
+
+```bash
+sqlite3 ~/.swarm/swarm.db "UPDATE agents SET host_agent = 'grok' WHERE name IN ('Forge','Brillo','Quill');"
 ```
 
 ---

--- a/bin/swarm
+++ b/bin/swarm
@@ -1,16 +1,41 @@
-#!/usr/bin/env node
-try {
-  await import('../dist/index.js');
-} catch (err) {
-  if (err?.message?.includes('NODE_MODULE_VERSION')) {
-    const { execFileSync } = await import('node:child_process');
-    const path = await import('node:path');
-    const root = path.dirname(path.dirname(new URL(import.meta.url).pathname));
-    process.stderr.write('Rebuilding native modules for current Node version...\n');
-    execFileSync('npm', ['rebuild', 'better-sqlite3'], { cwd: root, stdio: 'inherit' });
-    // Re-exec the process since Node caches native modules
-    execFileSync(process.execPath, process.argv.slice(1), { cwd: process.cwd(), stdio: 'inherit' });
-  } else {
-    throw err;
-  }
+#!/usr/bin/env bash
+# Swarm CLI launcher.
+# Prefer a pinned Node so better-sqlite3's native ABI matches across agents:
+#   1. $SWARM_NODE (absolute path to node binary)
+#   2. ~/.swarm/node-path (machine-local pin — do not commit)
+#   3. first `node` on PATH
+set -euo pipefail
+
+# Resolve through symlinks (e.g. /opt/homebrew/bin/swarm → repo bin/swarm)
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "${SOURCE}" ]; do
+  DIR="$(cd -P "$(dirname "${SOURCE}")" && pwd)"
+  SOURCE="$(readlink "${SOURCE}")"
+  [[ "${SOURCE}" != /* ]] && SOURCE="${DIR}/${SOURCE}"
+done
+ROOT="$(cd -P "$(dirname "${SOURCE}")/.." && pwd)"
+ENTRY="${ROOT}/bin/swarm-entry.mjs"
+
+resolve_node() {
+  if [ -n "${SWARM_NODE:-}" ] && [ -x "${SWARM_NODE}" ]; then
+    printf '%s\n' "${SWARM_NODE}"
+    return
+  fi
+  if [ -f "${HOME}/.swarm/node-path" ]; then
+    local pinned
+    pinned="$(head -1 "${HOME}/.swarm/node-path" | tr -d '\r\n')"
+    if [ -n "${pinned}" ] && [ -x "${pinned}" ]; then
+      printf '%s\n' "${pinned}"
+      return
+    fi
+  fi
+  command -v node
 }
+
+NODE="$(resolve_node)"
+if [ -z "${NODE}" ] || [ ! -x "${NODE}" ]; then
+  echo "swarm: node not found. Install Node >= 20 or set SWARM_NODE / ~/.swarm/node-path" >&2
+  exit 1
+fi
+
+exec "${NODE}" "${ENTRY}" "$@"

--- a/bin/swarm-entry.mjs
+++ b/bin/swarm-entry.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Swarm CLI entry. On better-sqlite3 NODE_MODULE_VERSION mismatch, download the
+ * matching official prebuild for this process's ABI (not `npm rebuild`, which
+ * thrash-fetches the wrong ABI and breaks every agent mid-session).
+ */
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+
+function isNativeMismatch(err) {
+  const msg = String(err?.message ?? err ?? '');
+  return (
+    msg.includes('NODE_MODULE_VERSION') ||
+    msg.includes('Could not locate the bindings file') ||
+    (msg.includes('better_sqlite3') && msg.includes('was compiled against'))
+  );
+}
+
+function prebuildTriple() {
+  const platform = process.platform; // darwin | linux | win32
+  const arch = process.arch; // arm64 | x64 | ...
+  if (platform === 'win32') return `win32-${arch}-msvc`;
+  return `${platform}-${arch}`;
+}
+
+function repairBetterSqlite3() {
+  if (process.env.SWARM_NATIVE_REPAIRED === '1') {
+    throw new Error(
+      'better-sqlite3 still fails after prebuild repair. ' +
+        'Pin a Node matching ~/.swarm/node-path or set SWARM_NODE, then retry.'
+    );
+  }
+
+  const pkgPath = path.join(ROOT, 'node_modules', 'better-sqlite3', 'package.json');
+  if (!fs.existsSync(pkgPath)) {
+    throw new Error(`better-sqlite3 not installed at ${pkgPath}`);
+  }
+  const version = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
+  const abi = process.versions.modules;
+  const triple = prebuildTriple();
+  const url =
+    `https://github.com/WiseLibs/better-sqlite3/releases/download/v${version}/` +
+    `better-sqlite3-v${version}-node-v${abi}-${triple}.tar.gz`;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-bsq-'));
+  const tgz = path.join(tmpDir, 'bsq.tgz');
+  process.stderr.write(
+    `swarm: better-sqlite3 ABI mismatch — downloading prebuild for node-v${abi} ${triple}...\n`
+  );
+
+  try {
+    execFileSync('curl', ['-fsSL', url, '-o', tgz], { stdio: 'inherit' });
+  } catch {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    throw new Error(
+      `Failed to download better-sqlite3 prebuild from ${url}. ` +
+        `Check network, or see TROUBLESHOOTING.md.`
+    );
+  }
+
+  const pkgRoot = path.join(ROOT, 'node_modules', 'better-sqlite3');
+  const buildDir = path.join(pkgRoot, 'build');
+  try {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+    execFileSync('tar', ['-xzf', tgz, '-C', pkgRoot], { stdio: 'inherit' });
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  // Re-exec under the same node so the new .node loads cleanly.
+  const env = { ...process.env, SWARM_NATIVE_REPAIRED: '1' };
+  try {
+    execFileSync(process.execPath, [fileURLToPath(import.meta.url), ...process.argv.slice(2)], {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+      env,
+    });
+    process.exit(0);
+  } catch (err) {
+    process.exit(err?.status ?? 1);
+  }
+}
+
+try {
+  // Probe the native module before loading the full CLI so we can repair once.
+  require(path.join(ROOT, 'node_modules', 'better-sqlite3'));
+  await import('../dist/index.js');
+} catch (err) {
+  if (isNativeMismatch(err)) {
+    try {
+      repairBetterSqlite3();
+    } catch (repairErr) {
+      console.error(`swarm: ${repairErr.message}`);
+      process.exit(1);
+    }
+  } else {
+    throw err;
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -161,12 +161,32 @@ if command -v gemini &>/dev/null; then
   installed=$((installed + 1))
 fi
 
+# ── Grok CLI ─────────────────────────────────────────────────────────────────
+
+if command -v grok &>/dev/null; then
+  echo "Found: Grok CLI"
+  GROK_HOME="${GROK_HOME:-$HOME/.grok}"
+  GROK_SKILLS="${GROK_HOME}/skills"
+  mkdir -p "$GROK_SKILLS"
+
+  # Symlink each skill — same SKILL.md layout as Claude Code; git pull updates them.
+  for skill in "${SKILLS[@]}"; do
+    skill_dir="${GROK_SKILLS}/${skill}"
+    mkdir -p "$skill_dir"
+    src="$(skill_source "$skill")"
+    ln -sf "$src" "${skill_dir}/SKILL.md"
+    echo "  Linked: ${GROK_SKILLS/#$HOME/~}/${skill}/SKILL.md → ${src}"
+  done
+
+  installed=$((installed + 1))
+fi
+
 # ── Swarm awareness hook ─────────────────────────────────────────────────────
 
 HOOK_SCRIPT="${SWARM_DIR}/hooks/swarm-awareness.sh"
 if command -v claude &>/dev/null && [ -f "$HOOK_SCRIPT" ]; then
   echo ""
-  echo "Installing swarm awareness hook..."
+  echo "Installing swarm awareness hook (Claude Code)..."
 
   SETTINGS_FILE="$HOME/.claude/settings.json"
   if [ -f "$SETTINGS_FILE" ]; then
@@ -208,6 +228,33 @@ if command -v claude &>/dev/null && [ -f "$HOOK_SCRIPT" ]; then
   fi
 fi
 
+if command -v grok &>/dev/null && [ -f "$HOOK_SCRIPT" ]; then
+  echo ""
+  echo "Installing swarm awareness hook (Grok CLI)..."
+  GROK_HOME="${GROK_HOME:-$HOME/.grok}"
+  GROK_HOOKS="${GROK_HOME}/hooks"
+  mkdir -p "$GROK_HOOKS"
+  # Grok discovers always-trusted global hooks from ~/.grok/hooks/*.json
+  cat > "${GROK_HOOKS}/swarm-awareness.json" << HOOK
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HOOK_SCRIPT}",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+HOOK
+  echo "  Installed: ${GROK_HOOKS/#$HOME/~}/swarm-awareness.json"
+fi
+
 # ── swarm CLI in PATH ────────────────────────────────────────────────────────
 
 if ! command -v swarm &>/dev/null; then
@@ -230,11 +277,11 @@ fi
 
 echo ""
 if [ $installed -eq 0 ]; then
-  echo "No supported agents found (checked: claude, codex, gemini)."
+  echo "No supported agents found (checked: claude, codex, gemini, grok)."
   echo "You can still use the CLI directly: ${SWARM_BIN} help"
 else
   echo "Done. ${installed} agent platform(s) configured."
-  echo "Claude skills are symlinked. Codex skills are copied; rerun ./install.sh after pulling swarm updates."
+  echo "Claude/Grok skills are symlinked. Codex skills are copied; rerun ./install.sh after pulling swarm updates."
   echo ""
-  echo "To test: open a fresh Claude Code or Codex session and invoke join-swarm."
+  echo "To test: open a fresh Claude Code, Codex, or Grok session and invoke join-swarm."
 fi

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -32,6 +32,11 @@ The message appears directly in their terminal as input. They will see:
 [SWARM from YourName]: <message>
 ```
 
+On **Grok**, a normal send **queues** mid-turn (does not interrupt). Only use `--interject` / `--now` when you intentionally want send-now:
+```
+swarm send <agent-name> "<urgent message>" --interject
+```
+
 Send to everyone:
 ```
 swarm broadcast "<message>"
@@ -60,17 +65,18 @@ swarm read <agent-name> --lines 30
 This lets you monitor progress without interrupting them.
 
 ### Spawning New Agents
-When you need another local Claude Code agent, spawn it from the lead/current agent:
+When you need another local agent, spawn it from the lead/current agent:
 ```
 swarm spawn --name DevA --cwd /path/to/project --swarm <swarm-name>
+swarm spawn --agent grok --name Brillo --cwd /path/to/project --swarm <swarm-name>
 ```
 
-By default, `swarm spawn` auto-selects the terminal: Warp when running inside Warp, otherwise Cmux. Use `--terminal cmux` or `--terminal warp` to force one. Cmux opens the new agent in a new tab/surface in the current workspace and auto-joins it to the selected swarm.
+Supported `--agent` values: `claude` (default), `codex`, `grok`. By default, `swarm spawn` auto-selects the terminal: Warp when running inside Warp, otherwise Cmux. Use `--terminal cmux` or `--terminal warp` to force one. Cmux opens the new agent in a new tab/surface in the current workspace and auto-joins it to the selected swarm.
 
 In Warp:
 - Default: opens a new **tab** in the active Warp window via `warp://action/new_tab`, then pastes the join+exec command via Accessibility. Compact, but tabs in one window can't be individually targeted by `swarm send` (see "Warp push caveat" above).
 - `--window`: opens a separate Warp window via a Launch Configuration YAML (auto-runs the join command without keystrokes). Better for `--push` reliability since each window has a unique accessibility-visible title.
-- Codex agents (`--agent codex`) receive join instructions as their initial prompt instead of auto-running `swarm join`.
+- Codex and Grok agents (`--agent codex` / `--agent grok`) receive join instructions as their initial prompt instead of auto-running `swarm join`.
 
 ## Coordination Protocol
 

--- a/skill/join-swarm.md
+++ b/skill/join-swarm.md
@@ -25,6 +25,8 @@ Omit `--swarm` when no swarm name was provided and the CLI can infer the current
 
 - If the selected swarm is **empty** (no agents or "No agents in swarm"), join as **"Lead"** — you're the first agent in this project swarm, so you coordinate the team.
 - If agents **already exist in this swarm**, pick a short creative name that's unique within this swarm. Don't ask the user, just pick one.
+- **Never name yourself after your model or any AI model/product** (Fable, Claude, Codex, Sonnet, Grok, GPT, Gemini, …, with or without version suffixes). The CLI rejects these — a model-named agent is ambiguous the moment a second instance of that model joins.
+- This machine may reserve names for remote/OpenClaw agents via a **local-only** file `~/.swarm/reserved-names` (not in the repo). If `swarm join` rejects a name as reserved, pick another.
 
 2. Join the swarm with your chosen name. The CLI auto-detects your environment — if you're in Cmux it uses push delivery, otherwise it joins in headless mode with automatic message polling.
 

--- a/src/a2a-server.ts
+++ b/src/a2a-server.ts
@@ -1,0 +1,228 @@
+import http from 'http';
+import os from 'os';
+import { randomUUID } from 'crypto';
+import type Database from 'better-sqlite3';
+import { getAgent } from './registry.js';
+import { deliverToAgent } from './transport-router.js';
+import { spawnRedeliverWorker } from './redeliver.js';
+
+/**
+ * A2A server — makes a local (usually headless) swarm agent reachable from
+ * other machines. Remote swarms register this endpoint via
+ * `swarm register-a2a <name> --endpoint http://<tailscale-ip>:<port>`,
+ * and their sends land in this machine's swarm DB inbox, where the local
+ * agent picks them up via `swarm inbox` / the awareness hook.
+ *
+ * Uses the @a2a-js/sdk server request handler wired to a plain node:http
+ * server (no express), so the wire format always matches the SDK client
+ * used by A2ATransport.
+ */
+
+export interface A2AServeOptions {
+  db: Database.Database;
+  swarmId: string;
+  swarmName: string;
+  /** Local agent name whose inbox receives incoming messages. */
+  agentName: string;
+  port: number;
+  /** Interface to bind ('0.0.0.0', a specific IP, …). */
+  bind: string;
+  /** Base URL advertised in the agent card (what remote clients dial). */
+  advertiseUrl: string;
+  description?: string;
+}
+
+/** Prefer the Tailscale CGNAT address (100.64.0.0/10) so cross-machine
+ * registration works out of the box; fall back to any external IPv4. */
+export function detectAdvertiseHost(): string {
+  const ifaces = os.networkInterfaces();
+  let fallback: string | null = null;
+  for (const addrs of Object.values(ifaces)) {
+    for (const addr of addrs ?? []) {
+      if (addr.family !== 'IPv4' || addr.internal) continue;
+      const [a, b] = addr.address.split('.').map(Number);
+      if (a === 100 && b >= 64 && b <= 127) return addr.address;
+      if (!fallback) fallback = addr.address;
+    }
+  }
+  return fallback ?? '127.0.0.1';
+}
+
+/** Incoming A2A text arrives pre-formatted by the remote swarm as
+ * "[SWARM from <name>]: <body>". Recover sender + body so the message
+ * threads into the local inbox with real attribution. */
+export function parseSwarmEnvelope(text: string): { from: string; body: string } {
+  const match = /^\[SWARM from ([^\]]+)\]:\s?([\s\S]*)$/.exec(text);
+  if (match) return { from: match[1], body: match[2] };
+  return { from: 'a2a-remote', body: text };
+}
+
+export async function startA2AServer(options: A2AServeOptions): Promise<http.Server> {
+  const { db, swarmId, swarmName, agentName, port, bind, advertiseUrl } = options;
+
+  const { DefaultRequestHandler, InMemoryTaskStore, JsonRpcTransportHandler } =
+    await import('@a2a-js/sdk/server');
+
+  const agentCard = {
+    protocolVersion: '0.3.0',
+    name: agentName,
+    description:
+      options.description ??
+      `Swarm agent "${agentName}" (swarm "${swarmName}") on ${os.hostname()} — messages land in its swarm inbox.`,
+    url: advertiseUrl,
+    preferredTransport: 'JSONRPC' as const,
+    version: '0.1.0',
+    capabilities: { streaming: false, pushNotifications: false, stateTransitionHistory: false },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [
+      {
+        id: 'swarm-inbox',
+        name: 'Swarm inbox delivery',
+        description: 'Delivers A2A messages into the local swarm inbox.',
+        tags: ['swarm'],
+        inputModes: ['text/plain'],
+        outputModes: ['text/plain'],
+      },
+    ],
+  };
+
+  const insertMessage = db.prepare(
+    'INSERT INTO messages (swarm_id, from_agent, to_agent, body, delivered, created_at) VALUES (?, ?, ?, ?, 0, ?)'
+  );
+  const markDelivered = db.prepare('UPDATE messages SET delivered = 1 WHERE id = ?');
+
+  const executor = {
+    async execute(requestContext: any, eventBus: any): Promise<void> {
+      const parts: any[] = requestContext.userMessage?.parts ?? [];
+      const text = parts
+        .filter((p) => p.kind === 'text' && typeof p.text === 'string')
+        .map((p) => p.text)
+        .join('\n');
+
+      let reply: string;
+      if (text.trim()) {
+        const { from, body } = parseSwarmEnvelope(text);
+        const inserted = insertMessage.run(swarmId, from, agentName, body, new Date().toISOString());
+        // Activation parity with local swarm: don't stop at the DB row — push the
+        // message into the recipient's terminal surface via the same transport a
+        // local `swarm send` uses (cmux keystrokes / Warp AppleScript). A recipient
+        // with no surface just falls back to inbox pickup (hook/poll), as locally.
+        // delivered stays 0 on push failure so the local redeliver worker retries.
+        reply = `Queued to ${agentName}'s inbox in swarm "${swarmName}" on ${os.hostname()}.`;
+        const localTarget = getAgent(db, swarmId, agentName);
+        if (localTarget && localTarget.agent_type !== 'a2a') {
+          try {
+            const push = await deliverToAgent(localTarget, `[SWARM from ${from}]: ${body}`);
+            if (push.delivered) {
+              markDelivered.run(inserted.lastInsertRowid);
+              reply = `Delivered to ${agentName} on ${os.hostname()} (pushed to terminal).`;
+            } else {
+              // Busy surface (e.g. recipient mid-turn). The detached worker retries
+              // on backoff and lands the push once the surface frees up — the same
+              // recovery path a local send uses.
+              console.error(`[a2a-server] push to ${agentName} not delivered: ${push.error ?? 'unknown'}`);
+              spawnRedeliverWorker();
+              reply = `Queued for ${agentName} on ${os.hostname()} (surface busy, retry worker spawned).`;
+            }
+          } catch (err: any) {
+            // Push is best-effort; the inbox row already guarantees delivery.
+            console.error(`[a2a-server] push to ${agentName} threw: ${err?.message ?? err}`);
+            spawnRedeliverWorker();
+          }
+        }
+      } else {
+        reply = `Ignored: no text content for ${agentName}.`;
+      }
+
+      eventBus.publish({
+        kind: 'message',
+        messageId: randomUUID(),
+        role: 'agent',
+        parts: [{ kind: 'text', text: reply }],
+        contextId: requestContext.contextId,
+      });
+      eventBus.finished();
+    },
+    async cancelTask(): Promise<void> {
+      // Deliveries are instantaneous; nothing to cancel.
+    },
+  };
+
+  const requestHandler = new DefaultRequestHandler(
+    agentCard as any,
+    new InMemoryTaskStore(),
+    executor as any
+  );
+  const rpcHandler = new JsonRpcTransportHandler(requestHandler);
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      if (req.method === 'HEAD') {
+        res.writeHead(200).end();
+        return;
+      }
+      if (req.method === 'GET' && req.url?.startsWith('/.well-known/agent-card.json')) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(agentCard));
+        return;
+      }
+      if (req.method === 'POST') {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(chunk as Buffer);
+        let body: unknown;
+        try {
+          body = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+        } catch {
+          res.writeHead(400, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }));
+          return;
+        }
+        const result = await rpcHandler.handle(body);
+        if (result && typeof (result as any)[Symbol.asyncIterator] === 'function') {
+          // Streaming method (message/stream etc.) — emit Server-Sent Events.
+          res.writeHead(200, {
+            'content-type': 'text/event-stream',
+            'cache-control': 'no-store',
+            connection: 'keep-alive',
+          });
+          for await (const event of result as AsyncGenerator<unknown>) {
+            res.write(`data: ${JSON.stringify(event)}\n\n`);
+          }
+          res.end();
+        } else {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify(result));
+        }
+        return;
+      }
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+    } catch (err: any) {
+      if (!res.headersSent) res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32603, message: err?.message ?? 'internal error' } }));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, bind, () => resolve());
+  });
+
+  // Ephemeral port (0): patch the advertised URL with the real bound port so
+  // the card always points somewhere dialable.
+  const bound = server.address();
+  if (bound && typeof bound === 'object') {
+    try {
+      const url = new URL(agentCard.url);
+      if (url.port === '0' || port === 0) {
+        url.port = String(bound.port);
+        agentCard.url = url.toString();
+      }
+    } catch {
+      // Leave a hand-crafted advertise URL untouched.
+    }
+  }
+
+  return server;
+}

--- a/src/cmux-transport.ts
+++ b/src/cmux-transport.ts
@@ -1,5 +1,5 @@
-import { Transport, TransportAgent, TransportDeliveryResult } from './transport-interface.js';
-import { sendToSurface, SurfaceGoneError, isSurfaceAlive } from './transport.js';
+import { Transport, TransportAgent, TransportDeliveryResult, DeliveryOptions } from './transport-interface.js';
+import { sendToSurface, notifySurface, SurfaceGoneError, isSurfaceAlive } from './transport.js';
 
 // A keystroke push is reliable only for a single short send. Typing a long,
 // multi-chunk message into a live Claude Code TUI silently drops chunks (the
@@ -20,18 +20,61 @@ export function buildPushText(formattedText: string): string {
   return nudge.length <= PUSH_MAX_CHARS ? nudge : nudge.slice(0, PUSH_MAX_CHARS);
 }
 
+/**
+ * How many Enter keypresses after typing. Grok queues mid-turn input on a single
+ * Enter (Ctrl+; queue path); a second Enter is send-now/interject. Default is 1
+ * so normal swarm traffic does not interrupt a running Grok turn.
+ */
+export function enterCountForDelivery(
+  hostAgent: string | null | undefined,
+  options?: DeliveryOptions
+): number {
+  if (options?.interject && hostAgent === 'grok') return 2;
+  return 1;
+}
+
+/** Codex TUIs are fragile under keystroke injection (reasoning-level pickers, mid-turn queues). */
+export function prefersNotifyDelivery(hostAgent: string | null | undefined, options?: DeliveryOptions): boolean {
+  // Explicit interject still uses keystrokes so a human/lead can force-submit.
+  if (options?.interject) return false;
+  return hostAgent === 'codex';
+}
+
 export class CmuxTransport implements Transport {
-  async deliverMessage(agent: TransportAgent, formattedText: string): Promise<TransportDeliveryResult> {
+  async deliverMessage(
+    agent: TransportAgent,
+    formattedText: string,
+    options?: DeliveryOptions
+  ): Promise<TransportDeliveryResult> {
     // Cmux socket only. There used to be an AppleScript clipboard-paste fallback
     // here, but it pasted into whatever tab was FOCUSED and misrouted messages
     // (the "[SWARM from Bob]" incident); it was removed. A socket failure now
     // returns delivered=false: the message stays queued in the DB (inbox/hook
     // pickup) and the redeliver worker retries the socket path.
+    const pushText = buildPushText(formattedText);
     try {
-      sendToSurface(agent.surface_id, buildPushText(formattedText), agent.workspace_id);
+      if (prefersNotifyDelivery(agent.host_agent, options)) {
+        const match = formattedText.match(/^\[SWARM from ([^\]]+)\]/);
+        const sender = match ? match[1] : 'swarm';
+        notifySurface(
+          agent.surface_id,
+          `SWARM from ${sender}`,
+          `${pushText} — run: swarm inbox`,
+          agent.workspace_id
+        );
+        return { delivered: true };
+      }
+
+      const enterCount = enterCountForDelivery(agent.host_agent, options);
+      sendToSurface(agent.surface_id, pushText, agent.workspace_id, { enterCount });
       return { delivered: true };
     } catch (err) {
       if (!(err instanceof SurfaceGoneError)) throw err;
+      // Codex notify-only path: if notify fails, try one keystroke nudge as last resort
+      // only when interject was requested; otherwise leave it for inbox/redeliver.
+      if (prefersNotifyDelivery(agent.host_agent, options)) {
+        return { delivered: false, error: `${agent.name}'s terminal is not reachable via cmux notify` };
+      }
       return { delivered: false, error: `${agent.name}'s terminal is not reachable via the cmux socket` };
     }
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -36,6 +36,11 @@ function ensureLegacyAgentColumns(db: Database.Database): void {
   if (!columns.has('endpoint_url')) {
     db.exec("ALTER TABLE agents ADD COLUMN endpoint_url TEXT");
   }
+  // Host harness (claude-code | codex | grok). Used for delivery quirks such as
+  // Grok needing a second Enter to submit interjected input instead of queueing it.
+  if (!columns.has('host_agent')) {
+    db.exec('ALTER TABLE agents ADD COLUMN host_agent TEXT');
+  }
 }
 
 function createSwarmsTable(db: Database.Database): void {
@@ -71,6 +76,7 @@ function createCurrentTables(db: Database.Database): void {
       last_heartbeat TEXT NOT NULL,
       agent_type TEXT NOT NULL DEFAULT 'cmux',
       endpoint_url TEXT,
+      host_agent TEXT,
       FOREIGN KEY (swarm_id) REFERENCES swarms(id) ON DELETE CASCADE,
       UNIQUE (swarm_id, name)
     );
@@ -126,6 +132,7 @@ function migrateAgents(db: Database.Database): void {
         last_heartbeat TEXT NOT NULL,
         agent_type TEXT NOT NULL DEFAULT 'cmux',
         endpoint_url TEXT,
+        host_agent TEXT,
         FOREIGN KEY (swarm_id) REFERENCES swarms(id) ON DELETE CASCADE,
         UNIQUE (swarm_id, name)
       );
@@ -136,11 +143,11 @@ function migrateAgents(db: Database.Database): void {
       -- the NOCASE unique constraint and leave the migration permanently failing.
       INSERT INTO agents_new (
         id, swarm_id, name, description, surface_id, workspace_id, ppid,
-        joined_at, last_heartbeat, agent_type, endpoint_url
+        joined_at, last_heartbeat, agent_type, endpoint_url, host_agent
       )
       SELECT
         id, '${DEFAULT_SWARM_ID}', name, description, surface_id, workspace_id, ppid,
-        joined_at, last_heartbeat, agent_type, endpoint_url
+        joined_at, last_heartbeat, agent_type, endpoint_url, host_agent
       FROM agents a
       WHERE NOT EXISTS (
         SELECT 1 FROM agents b

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,10 +2,11 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-export type HostAgent = 'claude-code' | 'codex';
+export type HostAgent = 'claude-code' | 'codex' | 'grok';
 
 const SWARM_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 const HOOK_SCRIPT = path.join(SWARM_DIR, 'hooks', 'swarm-awareness-headless.sh');
+const AWARENESS_HOOK_SCRIPT = path.join(SWARM_DIR, 'hooks', 'swarm-awareness.sh');
 const CODEX_BASE_MARKER = '<!-- swarm-instructions -->';
 
 /**
@@ -17,14 +18,22 @@ export function detectHost(): HostAgent | null {
     return 'codex';
   }
   if (process.env.CLAUDE_CODE) return 'claude-code';
+  // Grok sets GROK_AGENT (often "1") in interactive sessions; Cmux labels launch kind.
+  if (process.env.CMUX_AGENT_LAUNCH_KIND === 'grok' || process.env.GROK_AGENT) {
+    return 'grok';
+  }
 
   const hasCodexConfig = fs.existsSync(path.join(getCodexHome(), 'config.toml'));
   const hasClaudeConfig = fs.existsSync(path.join(os.homedir(), '.claude', 'settings.json'));
+  const hasGrokConfig = fs.existsSync(path.join(getGrokHome(), 'config.toml'));
 
-  if (hasCodexConfig && !hasClaudeConfig) return 'codex';
-  if (hasClaudeConfig && !hasCodexConfig) return 'claude-code';
+  const matches: HostAgent[] = [];
+  if (hasCodexConfig) matches.push('codex');
+  if (hasClaudeConfig) matches.push('claude-code');
+  if (hasGrokConfig) matches.push('grok');
 
-  return null;
+  // Only fall back to config when a single host is unambiguous.
+  return matches.length === 1 ? matches[0] : null;
 }
 
 /**
@@ -41,6 +50,9 @@ export function installHook(host: HostAgent, agentName: string, swarmId: string,
     case 'codex':
       installCodexHook(agentName, swarmId, swarmName);
       break;
+    case 'grok':
+      installGrokHook();
+      break;
   }
 }
 
@@ -54,6 +66,9 @@ export function removeHook(host: HostAgent, agentName: string, swarmId?: string)
       break;
     case 'codex':
       removeCodexHook(agentName, swarmId);
+      break;
+    case 'grok':
+      // Durable global hook stays installed (same model as Claude Code installer hook).
       break;
   }
 }
@@ -75,6 +90,14 @@ ${quotedSwarmBin} hook-context 2>/dev/null || true
 
 function getClaudeSettingsPath(): string {
   return path.join(os.homedir(), '.claude', 'settings.json');
+}
+
+function getGrokHome(): string {
+  return process.env.GROK_HOME || path.join(os.homedir(), '.grok');
+}
+
+function getGrokAwarenessHookPath(): string {
+  return path.join(getGrokHome(), 'hooks', 'swarm-awareness.json');
 }
 
 function getCodexHome(): string {
@@ -242,21 +265,31 @@ Your current identity is resolved by the swarm CLI from the terminal/session mar
   );
 
   const sessionPath = path.join(codexHome, 'swarm-session.md');
+  // Do NOT inject SWARM_AGENT_NAME=… — that only resolves headless rows and will
+  // mis-identify a Cmux Codex session that reuses a stale session file.
+  // Identity comes from CMUX_SURFACE_ID (auto) or `swarm whoami`.
   const sessionContent = `# Swarm Session
 
 This Codex terminal most recently joined swarm "${swarmName}" as "${agentName}".
-Do not rely on this file as the source of truth when multiple Codex sessions are open. Resolve the current terminal identity from the CLI:
+
+**Identity:** Always resolve from the live CLI (do not trust this file if multiple Codex tabs are open):
 
 \`\`\`bash
-SWARM_ID=${quotedSwarmId} ${quotedSwarmBin} whoami
-SWARM_ID=${quotedSwarmId} ${quotedSwarmBin} inbox
+${quotedSwarmBin} whoami
+${quotedSwarmBin} inbox
+${quotedSwarmBin} members
 \`\`\`
 
-To communicate in this swarm:
+When you see a Cmux **notification** titled \`SWARM from …\`, or a terminal nudge, run \`${swarmBin} inbox\` — full message bodies live in the inbox (Codex delivery uses notifications to avoid corrupting the TUI).
+
+To communicate:
 \`\`\`bash
-SWARM_ID=${quotedSwarmId} ${quotedSwarmBin} send <agent> "<message>"
-SWARM_ID=${quotedSwarmId} ${quotedSwarmBin} members
+${quotedSwarmBin} send <agent> "<message>"
+${quotedSwarmBin} broadcast "<message>"
+${quotedSwarmBin} status --set "<what you are doing>"
 \`\`\`
+
+Swarm id if needed: SWARM_ID=${quotedSwarmId}
 `;
   fs.writeFileSync(sessionPath, sessionContent);
   ensureInstructionsReference(
@@ -276,4 +309,32 @@ function removeCodexHook(agentName?: string, swarmId?: string): void {
     fs.unlinkSync(sessionPath);
     removeInstructionsReference('<!-- swarm-session -->');
   }
+}
+
+/**
+ * Install a durable global Grok UserPromptSubmit hook.
+ * Grok discovers hooks from ~/.grok/hooks/*.json (always trusted).
+ */
+function installGrokHook(): void {
+  const hookPath = getGrokAwarenessHookPath();
+  fs.mkdirSync(path.dirname(hookPath), { recursive: true });
+
+  // Prefer the durable awareness script; fall back to the generated headless one.
+  const command = fs.existsSync(AWARENESS_HOOK_SCRIPT) ? AWARENESS_HOOK_SCRIPT : HOOK_SCRIPT;
+  const payload = {
+    hooks: {
+      UserPromptSubmit: [
+        {
+          hooks: [
+            {
+              type: 'command',
+              command,
+              timeout: 5,
+            },
+          ],
+        },
+      ],
+    },
+  };
+  fs.writeFileSync(hookPath, `${JSON.stringify(payload, null, 2)}\n`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
   reapAll,
   reapIfDead,
   updateHeartbeat,
+  updateHostAgent,
   updateStatus,
   updateWorkspace,
 } from './registry.js';
@@ -37,6 +38,8 @@ import { installHook, removeHook, detectHost } from './hooks.js';
 import { registerSurface, removeSurface, loadSurface as loadSurfaceForHook } from './applescript-transport.js';
 import { ensureCodexTrust } from './codex-trust.js';
 import { parseGlobalFlags } from './args.js';
+import { assertNameNotReserved, assertNotModelName } from './reserved-names.js';
+import { detectAdvertiseHost, startA2AServer } from './a2a-server.js';
 
 const rawArgs = process.argv.slice(2);
 
@@ -112,6 +115,14 @@ function requireSelf(): { db: ReturnType<typeof getDb>; self: Agent; swarm: Swar
   }
 
   updateHeartbeat(db, self.swarm_id, self.surface_id);
+  // Persist host harness when known so delivery can apply host-specific quirks
+  // (e.g. Grok double-Enter). Refreshes existing sessions that joined before
+  // host_agent was recorded.
+  const host = detectHost();
+  if (host && self.host_agent !== host) {
+    updateHostAgent(db, self.swarm_id, self.surface_id, host);
+    self.host_agent = host;
+  }
   const swarm = getSwarmById(db, self.swarm_id) ?? getOrCreateSwarm(db);
   return { db, self, swarm, surfaceId: self.surface_id };
 }
@@ -143,11 +154,19 @@ Agent Management:
     [--description <text>] [--force]
   swarm unregister-a2a <name>                      Remove an A2A agent
   swarm discover <url>                             Fetch and display an A2A agent card
+  swarm serve [--name <agent>] [--port <n>]        Expose a local agent's inbox as an A2A
+    [--bind <ip>] [--advertise <url>]                endpoint (cross-machine delivery);
+    [--advertise-host <ip>] [--description <text>]   defaults: port 18790, bind 0.0.0.0,
+                                                     advertise Tailscale IPv4 when present
 
 Communication:
   swarm send <agent> <message>                     Send message within the current swarm
+    [--interject|--now]                              Grok: force send-now (double Enter);
+                                                     default single Enter queues mid-turn
   swarm broadcast <message>                        Send to all agents in the current swarm
-  swarm inbox [--peek]                             Read pending messages
+    [--interject|--now]
+  swarm inbox [--peek|--unread]                    Read pending messages
+                                                     (--unread is an alias; --peek does not advance cursor)
   swarm redeliver [--dry-run]                      Re-push queued messages recipients haven't seen
 
 Status:
@@ -157,10 +176,10 @@ Status:
 
 Local Agents:
   swarm spawn [--cwd <path>] [--autonomous]        Spawn an agent in a new tab
-    [--agent claude|codex] [--name <name>]
+    [--agent claude|codex|grok] [--name <name>]
     [--terminal auto|cmux|warp]                      (default: auto; --autonomous adds
-                                                      --dangerously-skip-permissions for claude
-                                                      and --yolo for codex)
+                                                      --dangerously-skip-permissions for claude,
+                                                      --yolo for codex, --always-approve for grok)
 
 Cmux-only:
   swarm read <agent> [--lines <n>]                 Read agent's terminal
@@ -192,7 +211,8 @@ function writeWarpOscTitle(surface: { ttyDevice?: string }, swarmName: string, a
 }
 
 function joinAsHeadless(db: ReturnType<typeof getDb>, swarm: Swarm, name: string, description?: string, pushEnabled?: boolean): void {
-  const agent = joinHeadlessAgent(db, swarm.id, name, description, { trackSession: true });
+  const host = detectHost();
+  const agent = joinHeadlessAgent(db, swarm.id, name, description, { trackSession: true, hostAgent: host });
   const parts: string[] = [`swarm: ${swarm.name}`, 'headless'];
 
   const surface = registerSurface(swarm.id, name, pushEnabled);
@@ -205,7 +225,6 @@ function joinAsHeadless(db: ReturnType<typeof getDb>, swarm: Swarm, name: string
     }
   }
 
-  const host = detectHost();
   if (host) {
     installHook(host, name, swarm.id, swarm.name);
     parts.push(`${host} hook`);
@@ -331,6 +350,13 @@ async function main() {
           console.error('Usage: swarm join <name> [--description <text>] [--headless] [--push] [--force] [--swarm <name>]');
           process.exit(1);
         }
+        try {
+          // Machine-local reserved list (~/.swarm/reserved-names) — never baked into the repo.
+          assertNameNotReserved(name);
+        } catch (err: any) {
+          console.error(err.message);
+          process.exit(1);
+        }
         const headless = hasFlag('--headless');
         const pushEnabled = hasFlag('--push');
         const force = hasFlag('--force');
@@ -360,9 +386,19 @@ async function main() {
           if (!surfaceId) {
             joinAsHeadless(db, swarm, name, description, pushEnabled);
           } else {
-            const agent = joinAgent(db, swarm.id, name, surfaceId, workspaceId, process.ppid, description);
+            const host = detectHost();
+            const agent = joinAgent(
+              db, swarm.id, name, surfaceId, workspaceId, process.ppid,
+              description, 'cmux', undefined, host
+            );
             renameTab(surfaceId, `${swarm.name}/${name}`, workspaceId);
-            console.log(`Joined swarm "${swarm.name}" as "${agent.name}" (surface: ${agent.surface_id})`);
+            // Refresh host session files (critical for Codex: stale
+            // ~/.codex/swarm-session.md otherwise points at a previous agent name).
+            if (host) {
+              try { installHook(host, name, swarm.id, swarm.name); } catch { /* non-fatal */ }
+            }
+            const hostLabel = host ? ` [${host}]` : '';
+            console.log(`Joined swarm "${swarm.name}" as "${agent.name}" (surface: ${agent.surface_id})${hostLabel}`);
           }
         }
         break;
@@ -391,6 +427,10 @@ async function main() {
           console.error('Usage: swarm register-a2a <name> --endpoint <url> [--description <text>] [--force] [--swarm <name>]');
           process.exit(1);
         }
+        // Model-name policy applies to A2A identities too, but NOT the machine-local
+        // reserved list — that list exists to hold names FOR remote A2A identities
+        // (see reserved-names.ts), so registration is how a reserved name gets claimed.
+        assertNotModelName(name);
 
         let parsedUrl: URL;
         try {
@@ -480,19 +520,63 @@ async function main() {
         break;
       }
 
+      case 'serve': {
+        const db = getDb();
+        let name = getFlag('--name');
+        let swarm: Swarm;
+        if (name) {
+          swarm = resolveSelectedSwarm(db);
+        } else {
+          const ctx = requireSelf();
+          name = ctx.self.name;
+          swarm = ctx.swarm;
+        }
+        if (!getAgent(db, swarm.id, name)) {
+          console.warn(`Warning: no agent named "${name}" in swarm "${swarm.name}" — incoming messages will queue in the inbox anyway, but join first so you can read them as yourself.`);
+        }
+        const port = parseInt(getFlag('--port') ?? '18790', 10);
+        if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+          console.error(`Invalid --port: ${getFlag('--port')}`);
+          process.exit(1);
+        }
+        const bind = getFlag('--bind') ?? '0.0.0.0';
+        const advertiseHost = getFlag('--advertise-host') ?? detectAdvertiseHost();
+        const advertiseUrl = getFlag('--advertise') ?? `http://${advertiseHost}:${port}/`;
+        await startA2AServer({
+          db,
+          swarmId: swarm.id,
+          swarmName: swarm.name,
+          agentName: name,
+          port,
+          bind,
+          advertiseUrl,
+          description: getFlag('--description'),
+        });
+        console.log(`A2A server for "${name}" (swarm "${swarm.name}") listening on ${bind}:${port}`);
+        console.log(`Agent card: ${advertiseUrl.replace(/\/$/, '')}/.well-known/agent-card.json`);
+        console.log(`Register from a remote machine with:`);
+        console.log(`  swarm register-a2a ${name} --endpoint ${advertiseUrl.replace(/\/$/, '')}`);
+        // Keep serving until killed.
+        await new Promise(() => {});
+        break;
+      }
+
       case 'send': {
         const { db, self } = requireSelf();
-        const targetName = args[1];
-        const message = args.slice(2).join(' ');
+        // Flags may appear anywhere before/among free-text; strip them from the body.
+        const interject = hasFlag('--interject') || hasFlag('--now');
+        const tokens = args.slice(1).filter(a => a !== '--interject' && a !== '--now');
+        const targetName = tokens[0];
+        const message = tokens.slice(1).join(' ');
         if (!targetName || !message) {
-          console.error('Usage: swarm send <agent> <message>');
+          console.error('Usage: swarm send <agent> <message> [--interject|--now]');
           process.exit(1);
         }
         if (targetName.toLowerCase() === self.name.toLowerCase()) {
           console.error('Cannot send a message to yourself.');
           process.exit(1);
         }
-        const result = await sendMessage(db, self.swarm_id, self.name, targetName, message);
+        const result = await sendMessage(db, self.swarm_id, self.name, targetName, message, { interject });
         console.log(result.message);
         // Push failed → the recipient may be idle with no upcoming turn to poll
         // the inbox. A detached worker retries the push on a backoff schedule.
@@ -502,12 +586,13 @@ async function main() {
 
       case 'broadcast': {
         const { db, self } = requireSelf();
-        const message = args.slice(1).join(' ');
+        const interject = hasFlag('--interject') || hasFlag('--now');
+        const message = args.slice(1).filter(a => a !== '--interject' && a !== '--now').join(' ');
         if (!message) {
-          console.error('Usage: swarm broadcast <message>');
+          console.error('Usage: swarm broadcast <message> [--interject|--now]');
           process.exit(1);
         }
-        const result = await broadcastMessage(db, self.swarm_id, self.name, message);
+        const result = await broadcastMessage(db, self.swarm_id, self.name, message, { interject });
         const reached = result.sent + result.queued;
         let line = `Broadcast to ${reached} agent(s)`;
         if (result.queued > 0) line += ` (${result.queued} via inbox)`;
@@ -521,6 +606,8 @@ async function main() {
 
       case 'inbox': {
         const { db, self } = requireSelf();
+        // --unread: common agent habit; same as default (show unread, advance cursor).
+        // --peek: show without advancing.
         const peek = hasFlag('--peek');
         const messages = getInbox(db, self.swarm_id, self.name, peek);
         if (messages.length === 0) {
@@ -548,7 +635,12 @@ async function main() {
           for (const agent of agents) {
             const you = self && agent.name.toLowerCase() === self.name.toLowerCase() ? ' (you)' : '';
             const desc = agent.description ? ` — ${agent.description}` : '';
-            const type = agent.agent_type === 'a2a' ? ` [a2a] @ ${agent.endpoint_url}` : agent.agent_type === 'headless' ? ' [headless]' : ' [cmux]';
+            const host = agent.host_agent ? `/${agent.host_agent}` : '';
+            const type = agent.agent_type === 'a2a'
+              ? ` [a2a] @ ${agent.endpoint_url}`
+              : agent.agent_type === 'headless'
+                ? ` [headless${host}]`
+                : ` [cmux${host}]`;
             console.log(`  ${agent.name}${type}${you}${desc}`);
           }
           console.log(`\n${agents.length} agent(s)`);
@@ -586,6 +678,7 @@ async function main() {
         console.log(`Swarm: ${swarm.name}`);
         console.log(`Swarm ID: ${self.swarm_id}`);
         console.log(`Type: ${self.agent_type}`);
+        if (self.host_agent) console.log(`Host: ${self.host_agent}`);
         console.log(`Surface: ${self.surface_id}`);
         console.log(`Workspace: ${self.workspace_id ?? 'N/A'}`);
         console.log(`Joined: ${self.joined_at}`);
@@ -634,6 +727,8 @@ async function main() {
 
         let agentCmd: string;
         let agentLabel: string;
+        // Agents that receive join instructions as their initial prompt (no post-spawn /join-swarm).
+        let joinViaPrompt = false;
         if (agentFlag === 'claude') {
           agentCmd = autonomous ? 'claude --dangerously-skip-permissions' : 'claude';
           agentLabel = 'Claude Code';
@@ -661,8 +756,23 @@ async function main() {
             : `Join the local swarm. First run ${swarmBin} members ${swarmFlag}. If there are no agents, join as "Lead"; otherwise choose a short unique creative name. Join by running ${swarmBin} join "<chosen-name>" ${swarmFlag}. Then run ${swarmBin} inbox and ${swarmBin} members ${swarmFlag}. Stay available for swarm messages and respond using ${swarmBin} send <agent> "<message>".`;
           agentCmd = `codex --cd ${shellQuote(absoluteCwd)}${perms} ${shellQuote(joinInstruction)}`;
           agentLabel = 'Codex CLI';
+          joinViaPrompt = true;
+        } else if (agentFlag === 'grok') {
+          // Grok CLI: pass join as the initial TUI prompt (positional [PROMPT]),
+          // same reliability pattern as Codex. Skills install provides /join-swarm
+          // for interactive use, but spawn shouldn't depend on TUI boot timing.
+          const absoluteCwd = path.resolve(cwd);
+          const perms = autonomous ? ' --always-approve' : '';
+          const swarmBin = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', 'bin', 'swarm');
+          const swarmFlag = `--swarm ${swarm.name}`;
+          const joinInstruction = name
+            ? `Join the local swarm as "${name}" by running: ${swarmBin} join "${name}" ${swarmFlag}. Then run ${swarmBin} inbox and ${swarmBin} members ${swarmFlag}. Stay available for swarm messages and respond using ${swarmBin} send <agent> "<message>".`
+            : `Join the local swarm. First run ${swarmBin} members ${swarmFlag}. If there are no agents, join as "Lead"; otherwise choose a short unique creative name. Join by running ${swarmBin} join "<chosen-name>" ${swarmFlag}. Then run ${swarmBin} inbox and ${swarmBin} members ${swarmFlag}. Stay available for swarm messages and respond using ${swarmBin} send <agent> "<message>".`;
+          agentCmd = `grok --cwd ${shellQuote(absoluteCwd)}${perms} ${shellQuote(joinInstruction)}`;
+          agentLabel = 'Grok CLI';
+          joinViaPrompt = true;
         } else {
-          console.error(`Unknown --agent "${agentFlag}". Supported: claude, codex.`);
+          console.error(`Unknown --agent "${agentFlag}". Supported: claude, codex, grok.`);
           process.exit(1);
         }
 
@@ -688,7 +798,7 @@ async function main() {
           if (agentFlag === 'claude' && name) {
             warpCommand = `swarm join ${shellQuote(name)} --swarm ${shellQuote(swarm.name)}${pushFlag} && exec ${agentCmd}`;
             willAutoJoin = true;
-          } else if (agentFlag === 'codex') {
+          } else if (joinViaPrompt) {
             warpCommand = agentCmd;
             willAutoJoin = true;
           } else {
@@ -770,8 +880,8 @@ async function main() {
         const location = spawnedInCurrentWorkspace ? 'new tab' : 'new workspace';
         console.log(`Spawned new ${agentLabel} session in ${cwd} (${location}: ${result.workspaceRef ?? 'current workspace'}, ${result.surfaceRef})`);
 
-        if (agentFlag === 'codex') {
-          console.log('Codex received the join instructions as its initial prompt.');
+        if (joinViaPrompt) {
+          console.log(`${agentLabel} received the join instructions as its initial prompt.`);
           break;
         }
 

--- a/src/mailbox.ts
+++ b/src/mailbox.ts
@@ -1,6 +1,7 @@
 import type Database from 'better-sqlite3';
 import { deliverToAgent } from './transport-router.js';
 import { getAgent, listAgents } from './registry.js';
+import type { DeliveryOptions } from './transport-interface.js';
 
 export interface Message {
   id: number;
@@ -17,7 +18,8 @@ export async function sendMessage(
   swarmId: string,
   fromName: string,
   toName: string,
-  body: string
+  body: string,
+  options?: DeliveryOptions
 ): Promise<{ delivered: boolean; queued: boolean; message: string }> {
   const target = getAgent(db, swarmId, toName);
   if (!target) {
@@ -37,20 +39,18 @@ export async function sendMessage(
 
   const msgId = result.lastInsertRowid;
 
-  const deliveryResult = await deliverToAgent(target, formatted);
+  const deliveryResult = await deliverToAgent(target, formatted, options);
   if (deliveryResult.delivered) {
     db.prepare('UPDATE messages SET delivered = 1 WHERE id = ?').run(msgId);
     return { delivered: true, queued: false, message: `Message sent to ${toName}` };
   } else {
-    // A2A agents can't read the local swarm inbox, so don't claim it was saved there
-    if (target.agent_type === 'a2a') {
-      return { delivered: false, queued: false, message: `Failed to deliver to ${toName}: ${deliveryResult.error || 'endpoint unreachable'}` };
-    }
-    // For Cmux and headless agents: push failed but message is in the DB.
-    // The recipient will pick it up via `swarm inbox`, and the caller should
-    // spawn a redeliver worker so an idle recipient isn't stuck waiting for
-    // a turn that never comes (see redeliver.ts).
-    return { delivered: true, queued: true, message: `Message sent to ${toName} (queued for inbox)` };
+    // Push failed but the message is in the DB. Cmux/headless recipients pick it
+    // up via `swarm inbox`; a2a recipients get retried by the redeliver worker
+    // (their endpoint may be briefly down, e.g. a service restart) and can also
+    // read their inbox remotely (getSelf resolves SWARM_AGENT_NAME for a2a).
+    // The caller should spawn a redeliver worker so an idle recipient isn't
+    // stuck waiting for a turn that never comes (see redeliver.ts).
+    return { delivered: true, queued: true, message: `Message sent to ${toName} (queued for retry/inbox)` };
   }
 }
 
@@ -58,7 +58,8 @@ export async function broadcastMessage(
   db: Database.Database,
   swarmId: string,
   fromName: string,
-  body: string
+  body: string,
+  options?: DeliveryOptions
 ): Promise<{ sent: number; queued: number; failed: number }> {
   const agents = await listAgents(db, swarmId);
   const recipients = agents.filter(a => a.name !== fromName);
@@ -79,7 +80,7 @@ export async function broadcastMessage(
 
   // Deliver to all recipients in parallel
   const results = await Promise.all(
-    recipients.map(async agent => ({ agent, result: await deliverToAgent(agent, formatted) }))
+    recipients.map(async agent => ({ agent, result: await deliverToAgent(agent, formatted, options) }))
   );
 
   let sent = 0;
@@ -88,13 +89,11 @@ export async function broadcastMessage(
   for (const { agent, result } of results) {
     if (result.delivered) {
       sent++;
-    } else if (agent.agent_type === 'a2a') {
-      // A2A agents can't read the local inbox, so a failed push is a real miss.
-      failed++;
     } else {
-      // Cmux/headless: the broadcast row is in the DB and is inbox-readable
-      // (to_agent IS NULL), so the recipient still receives it on their next
-      // inbox poll even though the immediate push nudge failed. Mirrors sendMessage.
+      // The broadcast row is in the DB and is inbox-readable (to_agent IS NULL),
+      // so the recipient still receives it on their next inbox poll even though
+      // the immediate push failed — a2a agents included, since they can read
+      // their inbox remotely via SWARM_AGENT_NAME. Mirrors sendMessage.
       queued++;
     }
   }

--- a/src/redeliver.ts
+++ b/src/redeliver.ts
@@ -35,8 +35,10 @@ interface RedeliverOptions {
  *   - recipient's inbox cursor has NOT passed the message (cursor-passed means
  *     the hook/inbox already surfaced it — re-pushing would duplicate)
  *   - younger than REDELIVER_WINDOW_MS (never resurface resolved work)
- *   - recipient is not a2a (a failed a2a send was reported to the sender as a
- *     real failure; the sender may have already re-sent — re-pushing risks dupes)
+ *
+ * A2A recipients are eligible too: a failed a2a push is reported to the sender
+ * as queued (mailbox.ts), so the retry here is the delivery path — it covers
+ * a remote endpoint that was briefly down (service restart, network blip).
  *
  * Concurrency-safe: each message is claimed with an atomic
  * `UPDATE ... WHERE delivered = 0` before pushing and reverted on push failure,
@@ -57,7 +59,6 @@ export async function redeliverPending(
       ON c.swarm_id = m.swarm_id AND c.agent_name = m.to_agent COLLATE NOCASE
     WHERE m.delivered = 0
       AND m.to_agent IS NOT NULL
-      AND a.agent_type != 'a2a'
       AND m.id > COALESCE(c.last_read_id, 0)
       AND m.created_at > ?
     ORDER BY m.id ASC
@@ -173,7 +174,6 @@ export function hasPendingRedeliveries(db: Database.Database): boolean {
       ON c.swarm_id = m.swarm_id AND c.agent_name = m.to_agent COLLATE NOCASE
     WHERE m.delivered = 0
       AND m.to_agent IS NOT NULL
-      AND a.agent_type != 'a2a'
       AND m.id > COALESCE(c.last_read_id, 0)
       AND m.created_at > ?
     LIMIT 1

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -20,6 +20,8 @@ export interface Swarm {
   last_active_at: string;
 }
 
+export type HostAgentKind = 'claude-code' | 'codex' | 'grok';
+
 export interface Agent {
   id: string;
   swarm_id: string;
@@ -27,6 +29,8 @@ export interface Agent {
   description: string | null;
   agent_type: AgentType;
   endpoint_url: string | null;
+  /** Host harness that owns this terminal (claude-code | codex | grok). */
+  host_agent: HostAgentKind | null;
   surface_id: string;
   workspace_id: string | null;
   ppid: number;
@@ -197,10 +201,12 @@ export function joinAgent(
   ppid: number,
   description?: string,
   agentType: AgentType = 'cmux',
-  endpointUrl?: string
+  endpointUrl?: string,
+  hostAgent?: HostAgentKind | null
 ): Agent {
   const id = randomUUID();
   const now = nowIso();
+  const host = hostAgent ?? null;
 
   const tx = db.transaction(() => {
     const existing = getAgent(db, swarmId, name);
@@ -216,10 +222,10 @@ export function joinAgent(
     db.prepare(`
       INSERT OR REPLACE INTO agents (
         id, swarm_id, name, description, surface_id, workspace_id, ppid,
-        joined_at, last_heartbeat, agent_type, endpoint_url
+        joined_at, last_heartbeat, agent_type, endpoint_url, host_agent
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, swarmId, name, description ?? null, surfaceId, workspaceId ?? null, ppid, now, now, agentType, endpointUrl ?? null);
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, swarmId, name, description ?? null, surfaceId, workspaceId ?? null, ppid, now, now, agentType, endpointUrl ?? null, host);
 
     db.prepare('UPDATE swarms SET last_active_at = ? WHERE id = ?').run(now, swarmId);
   });
@@ -232,6 +238,7 @@ export function joinAgent(
     description: description ?? null,
     agent_type: agentType,
     endpoint_url: endpointUrl ?? null,
+    host_agent: host,
     surface_id: surfaceId,
     workspace_id: workspaceId ?? null,
     ppid,
@@ -271,7 +278,7 @@ export function joinHeadlessAgent(
   swarmId: string,
   name: string,
   description?: string,
-  options: HeadlessSessionOptions = {}
+  options: HeadlessSessionOptions & { hostAgent?: HostAgentKind | null } = {}
 ): Agent {
   if (options.trackSession) {
     // This TTY previously joined under a different identity — reap it so a
@@ -288,7 +295,10 @@ export function joinHeadlessAgent(
     throw new Error(`Agent "${name}" is already registered as a ${existing.agent_type} agent in this swarm. Choose a different name or remove the existing agent first.`);
   }
   const syntheticSurfaceId = `headless:${swarmId}:${name}`;
-  const agent = joinAgent(db, swarmId, name, syntheticSurfaceId, undefined, process.ppid, description, 'headless');
+  const agent = joinAgent(
+    db, swarmId, name, syntheticSurfaceId, undefined, process.ppid,
+    description, 'headless', undefined, options.hostAgent
+  );
   if (options.trackSession) {
     writeSessionMarker(swarmId, name);
   }
@@ -332,9 +342,11 @@ export function getSelf(db: Database.Database, swarmId?: string): Agent | null {
 
   const agentName = process.env.SWARM_AGENT_NAME;
   if (agentName) {
+    // Headless agents resolve by name; a2a agents too, so a remote agent can
+    // act as itself over SSH (e.g. `SWARM_AGENT_NAME=Fable swarm send ...`).
     const sql = resolvedSwarmId
-      ? "SELECT * FROM agents WHERE swarm_id = ? AND name = ? COLLATE NOCASE AND agent_type = 'headless' ORDER BY joined_at DESC LIMIT 1"
-      : "SELECT * FROM agents WHERE name = ? COLLATE NOCASE AND agent_type = 'headless' ORDER BY joined_at DESC LIMIT 1";
+      ? "SELECT * FROM agents WHERE swarm_id = ? AND name = ? COLLATE NOCASE AND agent_type IN ('headless', 'a2a') ORDER BY joined_at DESC LIMIT 1"
+      : "SELECT * FROM agents WHERE name = ? COLLATE NOCASE AND agent_type IN ('headless', 'a2a') ORDER BY joined_at DESC LIMIT 1";
     const params = resolvedSwarmId ? [resolvedSwarmId, agentName] : [agentName];
     return db.prepare(sql).get(...params) as Agent | undefined ?? null;
   }
@@ -380,6 +392,16 @@ export function updateStatus(db: Database.Database, swarmId: string, surfaceId: 
 
 export function updateWorkspace(db: Database.Database, swarmId: string, surfaceId: string, workspaceId: string): void {
   db.prepare('UPDATE agents SET workspace_id = ? WHERE swarm_id = ? AND surface_id = ?').run(workspaceId, swarmId, surfaceId);
+}
+
+export function updateHostAgent(
+  db: Database.Database,
+  swarmId: string,
+  surfaceId: string,
+  hostAgent: HostAgentKind
+): void {
+  db.prepare('UPDATE agents SET host_agent = ? WHERE swarm_id = ? AND surface_id = ?')
+    .run(hostAgent, swarmId, surfaceId);
 }
 
 export function updateHeartbeat(db: Database.Database, swarmId: string, surfaceId: string): void {

--- a/src/reserved-names.ts
+++ b/src/reserved-names.ts
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Machine-local reserved agent names (never shipped in the repo).
+ *
+ * Loaded from (first that exists wins for file paths; env is always merged):
+ *   - $SWARM_RESERVED_NAMES  — comma/space-separated list
+ *   - ~/.swarm/reserved-names — one name per line; # comments and blanks ignored
+ *
+ * Use this for local OpenClaw / remote A2A identities that must not be claimed
+ * by Cmux/headless agents on this machine (e.g. Forge, Cooper, Hermes).
+ */
+export function loadReservedNames(): Set<string> {
+  const names = new Set<string>();
+
+  const env = process.env.SWARM_RESERVED_NAMES;
+  if (env) {
+    for (const part of env.split(/[,\s]+/)) {
+      const n = part.trim();
+      if (n) names.add(n.toLowerCase());
+    }
+  }
+
+  const filePath = process.env.SWARM_RESERVED_NAMES_FILE
+    || path.join(os.homedir(), '.swarm', 'reserved-names');
+
+  try {
+    if (fs.existsSync(filePath)) {
+      const text = fs.readFileSync(filePath, 'utf-8');
+      for (const line of text.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        names.add(trimmed.toLowerCase());
+      }
+    }
+  } catch {
+    // Missing or unreadable file is fine — treat as empty.
+  }
+
+  return names;
+}
+
+/**
+ * Model/product names agents must never use as identities. An agent named
+ * after a model reads as "the model", not "an agent" — and collides the
+ * moment a second instance of that model joins. Matching normalizes
+ * separators and trailing version digits, so "Fable", "fable-5", and
+ * "GPT_5.6" are all rejected.
+ */
+const MODEL_NAME_BLOCKLIST = new Set([
+  'claude', 'fable', 'mythos', 'opus', 'sonnet', 'haiku',
+  'codex', 'gpt', 'chatgpt', 'openai',
+  'grok', 'gemini', 'copilot', 'cursor',
+  'llama', 'mistral', 'deepseek', 'qwen', 'kimi',
+]);
+
+export function modelNameViolation(name: string): string | null {
+  const normalized = name.toLowerCase().replace(/[\s._-]+/g, '');
+  const versionStripped = normalized.replace(/[0-9.]+$/, '');
+  for (const candidate of [normalized, versionStripped]) {
+    if (MODEL_NAME_BLOCKLIST.has(candidate)) return candidate;
+  }
+  return null;
+}
+
+export function assertNotModelName(name: string): void {
+  const model = modelNameViolation(name);
+  if (model) {
+    throw new Error(
+      `Agent name "${name}" matches a model/product name ("${model}"). Agents must not name themselves after models — pick a distinct handle (e.g. Scribe, Rivet, Pixel).`
+    );
+  }
+}
+
+export function assertNameNotReserved(name: string): void {
+  assertNotModelName(name);
+  const reserved = loadReservedNames();
+  if (reserved.has(name.toLowerCase())) {
+    throw new Error(
+      `Agent name "${name}" is reserved on this machine (see ~/.swarm/reserved-names or SWARM_RESERVED_NAMES). Choose a different name.`
+    );
+  }
+}

--- a/src/transport-interface.ts
+++ b/src/transport-interface.ts
@@ -7,6 +7,8 @@ export interface TransportAgent {
   surface_id: string;
   workspace_id: string | null;
   endpoint_url: string | null;
+  /** Host harness (claude-code | codex | grok); drives delivery quirks. */
+  host_agent?: string | null;
 }
 
 export interface TransportDeliveryResult {
@@ -14,7 +16,21 @@ export interface TransportDeliveryResult {
   error?: string;
 }
 
+/**
+ * Delivery policy for a push. Default is non-interruptive: type the message and
+ * submit once (on Grok this *queues* while a turn is running). Opt into
+ * `interject` only when you intentionally want send-now on hosts that queue.
+ */
+export interface DeliveryOptions {
+  /** Grok: second Enter forces send-now instead of queueing. No-op on Claude/Codex. */
+  interject?: boolean;
+}
+
 export interface Transport {
-  deliverMessage(agent: TransportAgent, formattedText: string): Promise<TransportDeliveryResult>;
+  deliverMessage(
+    agent: TransportAgent,
+    formattedText: string,
+    options?: DeliveryOptions
+  ): Promise<TransportDeliveryResult>;
   isAlive(agent: TransportAgent): Promise<boolean>;
 }

--- a/src/transport-router.ts
+++ b/src/transport-router.ts
@@ -1,4 +1,4 @@
-import { Transport, TransportAgent, TransportDeliveryResult } from './transport-interface.js';
+import { Transport, TransportAgent, TransportDeliveryResult, DeliveryOptions } from './transport-interface.js';
 import { CmuxTransport } from './cmux-transport.js';
 import { A2ATransport } from './a2a-transport.js';
 import { HeadlessTransport } from './headless-transport.js';
@@ -21,9 +21,13 @@ export function getTransport(agentType: string, swarmId?: string, agentName?: st
   }
 }
 
-export async function deliverToAgent(agent: TransportAgent, text: string): Promise<TransportDeliveryResult> {
+export async function deliverToAgent(
+  agent: TransportAgent,
+  text: string,
+  options?: DeliveryOptions
+): Promise<TransportDeliveryResult> {
   const transport = getTransport(agent.agent_type, agent.swarm_id, agent.name);
-  return transport.deliverMessage(agent, text);
+  return transport.deliverMessage(agent, text, options);
 }
 
 export async function isAgentAlive(agent: TransportAgent): Promise<boolean> {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -127,9 +127,63 @@ function releaseSurfaceLock(lockPath: string): void {
   try { fs.rmSync(lockPath, { recursive: true, force: true }); } catch {}
 }
 
-export function sendToSurface(surfaceId: string, text: string, workspaceId?: string | null): void {
+export interface SendToSurfaceOptions {
+  /**
+   * How many times to press Enter after typing. Grok's TUI queues interjected
+   * input on a single Enter and only submits on the second; Claude/Codex submit
+   * on the first. Default 1.
+   */
+  enterCount?: number;
+}
+
+/**
+ * Non-invasive surface wake-up via Cmux notifications (no keystrokes into the TUI).
+ * Preferred for Codex: typing into the prompt can open reasoning-level pickers or
+ * queue mid-turn and leave the agent stuck. Callers still store the full message
+ * in the DB for `swarm inbox`.
+ */
+export function notifySurface(
+  surfaceId: string,
+  title: string,
+  body: string,
+  workspaceId?: string | null
+): void {
+  const cmux = resolveCmux();
+  const safeTitle = sanitize(title).slice(0, 80) || 'SWARM';
+  const safeBody = sanitize(body).slice(0, 200) || 'New message — run: swarm inbox';
+  const args = ['notify', '--title', safeTitle, '--body', safeBody, '--surface', surfaceId];
+  if (workspaceId) args.push('--workspace', workspaceId);
+  try {
+    execFileSync(cmux, args, STDIO_OPTS);
+  } catch (err: any) {
+    if (isTransientCmuxError(err)) {
+      // One quick retry for flaky sockets.
+      sleep(0.2);
+      try {
+        execFileSync(cmux, args, STDIO_OPTS);
+      } catch {
+        // Still failing (busy surface under load). Surface as "gone" so the
+        // caller reports delivered=false and the message stays queued for the
+        // redeliver worker — a raw throw here crashed the whole CLI with the
+        // message already inserted, making successful queueing look like a
+        // failed send (field-observed on notify-path recipients under load).
+        throw new SurfaceGoneError(surfaceId);
+      }
+      return;
+    }
+    throw new SurfaceGoneError(surfaceId);
+  }
+}
+
+export function sendToSurface(
+  surfaceId: string,
+  text: string,
+  workspaceId?: string | null,
+  options?: SendToSurfaceOptions
+): void {
   const cmux = resolveCmux();
   const safe = sanitize(text);
+  const enterCount = Math.max(1, options?.enterCount ?? 1);
   const wsArgs = workspaceId ? ['--workspace', workspaceId] : [];
   const lockPath = acquireSurfaceLock(surfaceId);
   try {
@@ -156,7 +210,10 @@ export function sendToSurface(surfaceId: string, text: string, workspaceId?: str
         }
         // Let input settle before submitting
         sleep(0.1);
-        execFileSync(cmux, ['send-key', ...wsArgs, '--surface', surfaceId, 'Enter'], STDIO_OPTS);
+        for (let e = 0; e < enterCount; e++) {
+          execFileSync(cmux, ['send-key', ...wsArgs, '--surface', surfaceId, 'Enter'], STDIO_OPTS);
+          if (e + 1 < enterCount) sleep(0.05);
+        }
         return; // success
       } catch (err: any) {
         // A "broken pipe"/socket-reset means the cmux server dropped the connection

--- a/tests/a2a-server.test.ts
+++ b/tests/a2a-server.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getDbAt } from '../src/db.js';
+import { getOrCreateSwarm, joinHeadlessAgent } from '../src/registry.js';
+import { getInbox } from '../src/mailbox.js';
+import { parseSwarmEnvelope, startA2AServer } from '../src/a2a-server.js';
+import { A2ATransport } from '../src/a2a-transport.js';
+
+describe('parseSwarmEnvelope', () => {
+  test('recovers sender and body from the swarm wire format', () => {
+    const { from, body } = parseSwarmEnvelope('[SWARM from Scribe]: hello over there');
+    assert.strictEqual(from, 'Scribe');
+    assert.strictEqual(body, 'hello over there');
+  });
+
+  test('keeps multi-line bodies intact', () => {
+    const { from, body } = parseSwarmEnvelope('[SWARM from Sol]: line one\nline two');
+    assert.strictEqual(from, 'Sol');
+    assert.strictEqual(body, 'line one\nline two');
+  });
+
+  test('falls back to a2a-remote for unenveloped text', () => {
+    const { from, body } = parseSwarmEnvelope('raw a2a message');
+    assert.strictEqual(from, 'a2a-remote');
+    assert.strictEqual(body, 'raw a2a message');
+  });
+});
+
+// End-to-end over real HTTP with the same SDK client path A2ATransport uses in
+// production: remote swarm's deliverMessage → local serve → local inbox row.
+describe('swarm serve end-to-end', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-a2a-test-'));
+  const db = getDbAt(path.join(tmpDir, 'test.db'));
+  let server: import('http').Server | undefined;
+
+  after(() => {
+    server?.close();
+    db.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('delivers a remote swarm message into the local inbox', async () => {
+    const swarm = getOrCreateSwarm(db, 'serve-test');
+    joinHeadlessAgent(db, swarm.id, 'Fable', undefined, { trackSession: false });
+
+    server = await startA2AServer({
+      db,
+      swarmId: swarm.id,
+      swarmName: swarm.name,
+      agentName: 'Fable',
+      port: 0, // ephemeral
+      bind: '127.0.0.1',
+      advertiseUrl: 'http://127.0.0.1:0/', // rewritten below once the port is known
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === 'object');
+    const endpoint = `http://127.0.0.1:${address.port}`;
+
+    // Liveness probe the way registry cleanup does it.
+    const card = await fetch(`${endpoint}/.well-known/agent-card.json`).then(r => r.json()) as { name: string };
+    assert.strictEqual(card.name, 'Fable');
+
+    // Deliver exactly the way a remote swarm does.
+    const transport = new A2ATransport();
+    const result = await transport.deliverMessage(
+      { name: 'Fable', agent_type: 'a2a', endpoint_url: endpoint } as any,
+      '[SWARM from Scribe]: ping from the laptop swarm'
+    );
+    assert.strictEqual(result.delivered, true, result.error);
+
+    const inbox = getInbox(db, swarm.id, 'Fable');
+    assert.strictEqual(inbox.length, 1);
+    assert.strictEqual(inbox[0].from_agent, 'Scribe');
+    assert.strictEqual(inbox[0].body, 'ping from the laptop swarm');
+  });
+});

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -7,12 +7,15 @@ import { detectHost, installHook, removeHook } from '../src/hooks.js';
 
 const ORIGINAL_HOME = process.env.HOME;
 const CODEX_ENV_KEYS = ['CODEX_CLI', 'CODEX_CI', 'CODEX_THREAD_ID', 'CODEX_MANAGED_BY_NPM', 'CODEX_HOME'];
+const GROK_ENV_KEYS = ['GROK_AGENT', 'GROK_HOME', 'CMUX_AGENT_LAUNCH_KIND'];
 const ORIGINAL_CLAUDE_CODE = process.env.CLAUDE_CODE;
 const ORIGINAL_CODEX_ENV = new Map(CODEX_ENV_KEYS.map(key => [key, process.env[key]]));
+const ORIGINAL_GROK_ENV = new Map(GROK_ENV_KEYS.map(key => [key, process.env[key]]));
 
 function clearRuntimeEnv(): void {
   delete process.env.CLAUDE_CODE;
   for (const key of CODEX_ENV_KEYS) delete process.env[key];
+  for (const key of GROK_ENV_KEYS) delete process.env[key];
 }
 
 function withTempHome(): string {
@@ -31,6 +34,11 @@ afterEach(() => {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
   }
+  for (const key of GROK_ENV_KEYS) {
+    const value = ORIGINAL_GROK_ENV.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
 });
 
 describe('hook host detection', () => {
@@ -45,6 +53,21 @@ describe('hook host detection', () => {
     assert.strictEqual(detectHost(), 'codex');
   });
 
+  test('Grok runtime env is detected via GROK_AGENT or CMUX_AGENT_LAUNCH_KIND', () => {
+    const home = withTempHome();
+    fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(home, '.grok'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.claude', 'settings.json'), '{}\n');
+    fs.writeFileSync(path.join(home, '.grok', 'config.toml'), 'model = "test"\n');
+
+    process.env.GROK_AGENT = '1';
+    assert.strictEqual(detectHost(), 'grok');
+
+    delete process.env.GROK_AGENT;
+    process.env.CMUX_AGENT_LAUNCH_KIND = 'grok';
+    assert.strictEqual(detectHost(), 'grok');
+  });
+
   test('config fallback only detects a host when unambiguous', () => {
     const home = withTempHome();
     fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
@@ -56,6 +79,11 @@ describe('hook host detection', () => {
 
     fs.rmSync(path.join(home, '.claude'), { recursive: true, force: true });
     assert.strictEqual(detectHost(), 'codex');
+
+    fs.rmSync(path.join(home, '.codex'), { recursive: true, force: true });
+    fs.mkdirSync(path.join(home, '.grok'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.grok', 'config.toml'), 'model = "test"\n');
+    assert.strictEqual(detectHost(), 'grok');
   });
 });
 
@@ -125,5 +153,26 @@ describe('Claude hook state', () => {
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
     const commands = settings.hooks.UserPromptSubmit.flatMap((entry: any) => entry.hooks.map((hook: any) => hook.command));
     assert.deepStrictEqual(commands, ['/repo/hooks/swarm-awareness.sh']);
+  });
+});
+
+describe('Grok hook state', () => {
+  test('installing Grok hook writes durable UserPromptSubmit hook under ~/.grok/hooks', () => {
+    const home = withTempHome();
+    process.env.GROK_HOME = path.join(home, '.grok');
+
+    installHook('grok', 'Forge', 'swarm-a', 'project-a');
+
+    const hookPath = path.join(home, '.grok', 'hooks', 'swarm-awareness.json');
+    assert.ok(fs.existsSync(hookPath));
+    const payload = JSON.parse(fs.readFileSync(hookPath, 'utf-8'));
+    const command = payload.hooks.UserPromptSubmit[0].hooks[0].command as string;
+    assert.match(command, /swarm-awareness/);
+    assert.strictEqual(payload.hooks.UserPromptSubmit[0].hooks[0].type, 'command');
+    assert.strictEqual(payload.hooks.UserPromptSubmit[0].hooks[0].timeout, 5);
+
+    // Leave keeps the durable global hook (same model as Claude installer).
+    removeHook('grok', 'Forge', 'swarm-a');
+    assert.ok(fs.existsSync(hookPath));
   });
 });

--- a/tests/redeliver.test.ts
+++ b/tests/redeliver.test.ts
@@ -84,13 +84,19 @@ describe('redeliverPending', () => {
     assert.strictEqual(result.eligible, 0);
   });
 
-  test('skips broadcast rows, already-delivered messages, and a2a recipients', async () => {
-    addAgent('Remote', 'a2a');
+  test('skips broadcast rows and already-delivered messages', async () => {
     addMessage({ from: 'Alice', to: null });                 // broadcast
     addMessage({ from: 'Alice', to: 'Bob', delivered: 1 });  // push already succeeded
-    addMessage({ from: 'Alice', to: 'Remote' });             // a2a — sender was told it failed
     const result = await redeliverPending(db, { deliver: deliverOk });
     assert.strictEqual(result.eligible, 0);
+  });
+
+  test('retries queued a2a recipients (endpoint may have been briefly down)', async () => {
+    addAgent('Remote', 'a2a');
+    const id = addMessage({ from: 'Alice', to: 'Remote' }); // a2a push failed -> queued
+    const result = await redeliverPending(db, { deliver: deliverOk });
+    assert.deepStrictEqual(result, { eligible: 1, redelivered: 1, attempted: 1 });
+    assert.strictEqual(deliveredFlag(id), 1);
   });
 
   test('cursor guard matches case-insensitively', async () => {

--- a/tests/reserved-names.test.ts
+++ b/tests/reserved-names.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { assertNameNotReserved, loadReservedNames } from '../src/reserved-names.js';
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_ENV = process.env.SWARM_RESERVED_NAMES;
+const ORIGINAL_FILE = process.env.SWARM_RESERVED_NAMES_FILE;
+
+afterEach(() => {
+  process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_ENV === undefined) delete process.env.SWARM_RESERVED_NAMES;
+  else process.env.SWARM_RESERVED_NAMES = ORIGINAL_ENV;
+  if (ORIGINAL_FILE === undefined) delete process.env.SWARM_RESERVED_NAMES_FILE;
+  else process.env.SWARM_RESERVED_NAMES_FILE = ORIGINAL_FILE;
+});
+
+describe('reserved names (machine-local)', () => {
+  test('loads names from env and file, case-insensitive', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-reserved-'));
+    process.env.HOME = home;
+    delete process.env.SWARM_RESERVED_NAMES;
+    delete process.env.SWARM_RESERVED_NAMES_FILE;
+
+    const dir = path.join(home, '.swarm');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'reserved-names'), '# comment\nForge\nAnvil\n\n');
+
+    process.env.SWARM_RESERVED_NAMES = 'Cooper, Hermes';
+
+    const names = loadReservedNames();
+    assert.ok(names.has('forge'));
+    assert.ok(names.has('anvil'));
+    assert.ok(names.has('cooper'));
+    assert.ok(names.has('hermes'));
+    assert.ok(!names.has('scribe'));
+  });
+
+  test('assertNameNotReserved rejects reserved names', () => {
+    process.env.SWARM_RESERVED_NAMES = 'Forge';
+    delete process.env.SWARM_RESERVED_NAMES_FILE;
+    process.env.HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-reserved-'));
+
+    assert.throws(() => assertNameNotReserved('forge'), /reserved on this machine/i);
+    assert.doesNotThrow(() => assertNameNotReserved('Rivet'));
+  });
+});
+
+describe('model-name policy', () => {
+  test('rejects agents named after models, any casing or version suffix', () => {
+    delete process.env.SWARM_RESERVED_NAMES;
+    delete process.env.SWARM_RESERVED_NAMES_FILE;
+    process.env.HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-reserved-'));
+
+    for (const bad of ['Fable', 'fable-5', 'Codex', 'codex 5.6', 'GPT_5.6', 'Sonnet', 'grok4', 'Claude', 'Gemini']) {
+      assert.throws(() => assertNameNotReserved(bad), /model\/product name/i, bad);
+    }
+  });
+
+  test('allows ordinary handles, including ones containing digits', () => {
+    delete process.env.SWARM_RESERVED_NAMES;
+    delete process.env.SWARM_RESERVED_NAMES_FILE;
+    process.env.HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-reserved-'));
+
+    for (const ok of ['Scribe', 'Rivet', 'Yulan', 'Pixel2', 'Sol', 'Brillo']) {
+      assert.doesNotThrow(() => assertNameNotReserved(ok), ok);
+    }
+  });
+});

--- a/tests/transport.test.ts
+++ b/tests/transport.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import { isTransientCmuxError } from '../src/transport.js';
-import { buildPushText, PUSH_MAX_CHARS } from '../src/cmux-transport.js';
+import { buildPushText, enterCountForDelivery, prefersNotifyDelivery, PUSH_MAX_CHARS } from '../src/cmux-transport.js';
 
 // The transient/gone classification decides whether a failed cmux send is retried
 // (busy surface) or treated as a dead surface (which lets cleanupStale prune the
@@ -75,6 +75,25 @@ describe('buildPushText (single-chunk push, nudge for long messages)', () => {
     const long = `[SWARM from ${'N'.repeat(200)}]: ` + 'body '.repeat(50);
     const push = buildPushText(long);
     assert.ok(push.length <= PUSH_MAX_CHARS, `nudge too long: ${push.length}`);
+  });
+
+  test('default delivery is single Enter (queue on Grok); interject doubles only for Grok', () => {
+    assert.strictEqual(enterCountForDelivery('grok'), 1);
+    assert.strictEqual(enterCountForDelivery('grok', {}), 1);
+    assert.strictEqual(enterCountForDelivery('grok', { interject: false }), 1);
+    assert.strictEqual(enterCountForDelivery('grok', { interject: true }), 2);
+    assert.strictEqual(enterCountForDelivery('claude-code', { interject: true }), 1);
+    assert.strictEqual(enterCountForDelivery('codex', { interject: true }), 1);
+    assert.strictEqual(enterCountForDelivery(null, { interject: true }), 1);
+  });
+
+  test('Codex prefers non-invasive notify unless interject is requested', () => {
+    assert.strictEqual(prefersNotifyDelivery('codex'), true);
+    assert.strictEqual(prefersNotifyDelivery('codex', {}), true);
+    assert.strictEqual(prefersNotifyDelivery('codex', { interject: true }), false);
+    assert.strictEqual(prefersNotifyDelivery('grok'), false);
+    assert.strictEqual(prefersNotifyDelivery('claude-code'), false);
+    assert.strictEqual(prefersNotifyDelivery(null), false);
   });
 
   test('a long message with no parseable sender still nudges within one chunk', () => {


### PR DESCRIPTION
## What

Makes the swarm span machines with the same activation semantics as local delivery, plus a naming policy. Built, deployed, and verified live between yulanbots-mac-mini and the laptop over Tailscale (this bridge carried the coordination messages for its own review).

- **`swarm serve`** (new `src/a2a-server.ts`): exposes a local agent's inbox as an A2A endpoint — SDK request handler on plain `node:http` (no express), agent card + JSON-RPC `message/send` + SSE for streaming clients, Tailscale IPv4 auto-advertised. Incoming messages land in the local swarm DB **and are pushed into the recipient's terminal surface** via the local transport router (cmux keystrokes), with the redeliver worker as busy-surface fallback — i.e. cross-machine sends activate the recipient exactly like local sends.
- **A2A self-identity**: `getSelf` resolves `SWARM_AGENT_NAME` for `a2a` agents, so a remote agent can send/read as itself over SSH.
- **A2A redelivery**: failed a2a pushes are now reported as *queued* and retried by the existing worker (endpoint restarts no longer hard-fail sends). Removed the a2a exclusions in `redeliver.ts`.
- **Model-name policy**: agents may not name themselves after AI models/products (Fable, Codex, GPT, Grok, … incl. version/separator variants); enforced at `join` and `register-a2a`. The machine-local reserved list intentionally does NOT apply to `register-a2a` — that list exists to hold names *for* remote A2A identities.
- **Notify crash fix** (`transport.ts`): a second broken-pipe in `notifySurface`'s retry escaped as a raw throw and killed the CLI with exit 1 *after* the message row was inserted, making successful queueing look like a failed send. Now surfaces as delivered=false → queued.

## Deployment notes

- Both machines already run this exact commit (atomic dist swap; branch checked out clean on both).
- Known platform limit: a `swarm serve` under launchd can receive (DB) but not inject keystrokes — macOS cmux socket rejects out-of-session writers with broken pipe. Injection needs a session-context process (e.g. `swarm redeliver` sweeps from within a session; `redeliverPending`'s atomic claims make concurrent sweepers safe).

## Tests

98/98 on both machines (5 new: serve end-to-end through the real SDK client → inbox; envelope parsing; model-name rejection incl. version suffixes; a2a redelivery eligibility).

## Included baseline

This branch also commits the previously-deployed uncommitted baseline it builds on (`bin/swarm-entry.mjs`, `reserved-names`, hooks/transport WIP — Scribe's team's work, included as-is since the new code depends on it). Scribe: flagging that layer explicitly for your gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151SVT6xzcsEKLLPFp6PKNb