### PR TITLE
Wake idle Codex agents with a keystroke nudge after notify

### DIFF
--- a/src/cmux-transport.ts
+++ b/src/cmux-transport.ts
@@ -1,5 +1,5 @@
 import { Transport, TransportAgent, TransportDeliveryResult, DeliveryOptions } from './transport-interface.js';
-import { sendToSurface, notifySurface, SurfaceGoneError, isSurfaceAlive } from './transport.js';
+import { sendToSurface, notifySurface, readScreen, SurfaceGoneError, isSurfaceAlive } from './transport.js';
 
 // A keystroke push is reliable only for a single short send. Typing a long,
 // multi-chunk message into a live Claude Code TUI silently drops chunks (the
@@ -40,6 +40,19 @@ export function prefersNotifyDelivery(hostAgent: string | null | undefined, opti
   return hostAgent === 'codex';
 }
 
+/**
+ * A cmux notification alone does NOT wake an idle Codex agent — nothing starts
+ * a turn, so the message sits queued until a human prompts the TUI (field-
+ * observed 2026-07-14: assignments went undelivered until Tom manually nudged).
+ * Keystroke injection is only dangerous MID-turn (pickers, queued input); when
+ * the composer is idle, typing a one-line nudge + Enter is safe and starts a
+ * turn whose awareness hook reads the inbox. Discriminator: Codex renders
+ * "esc to interrupt" on its status line for the entire duration of a turn.
+ */
+export function isCodexScreenIdle(screen: string): boolean {
+  return !/esc to interrupt/i.test(screen);
+}
+
 export class CmuxTransport implements Transport {
   async deliverMessage(
     agent: TransportAgent,
@@ -62,6 +75,18 @@ export class CmuxTransport implements Transport {
           `${pushText} — run: swarm inbox`,
           agent.workspace_id
         );
+        // The notification alone can't wake an idle Codex agent (no turn starts).
+        // If the surface looks idle, follow with a one-line keystroke nudge to
+        // start a turn; if it's mid-turn (or the read fails), the notify + the
+        // agent's own task-boundary inbox checks cover it.
+        try {
+          const screen = readScreen(agent.surface_id, 30, agent.workspace_id);
+          if (isCodexScreenIdle(screen)) {
+            sendToSurface(agent.surface_id, pushText, agent.workspace_id, { enterCount: 1 });
+          }
+        } catch {
+          // Best-effort wake only — notify already succeeded, message is queued.
+        }
         return { delivered: true };
       }
 

--- a/tests/transport.test.ts
+++ b/tests/transport.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import { isTransientCmuxError } from '../src/transport.js';
-import { buildPushText, enterCountForDelivery, prefersNotifyDelivery, PUSH_MAX_CHARS } from '../src/cmux-transport.js';
+import { buildPushText, enterCountForDelivery, prefersNotifyDelivery, isCodexScreenIdle, PUSH_MAX_CHARS } from '../src/cmux-transport.js';
 
 // The transient/gone classification decides whether a failed cmux send is retried
 // (busy surface) or treated as a dead surface (which lets cleanupStale prune the
@@ -94,6 +94,20 @@ describe('buildPushText (single-chunk push, nudge for long messages)', () => {
     assert.strictEqual(prefersNotifyDelivery('grok'), false);
     assert.strictEqual(prefersNotifyDelivery('claude-code'), false);
     assert.strictEqual(prefersNotifyDelivery(null), false);
+  });
+
+  test('Codex idle detection keys off the "esc to interrupt" turn indicator', () => {
+    // Mid-turn: status line shows the interrupt hint for the whole turn.
+    assert.strictEqual(
+      isCodexScreenIdle('• Working (49s • esc to interrupt) · 1 background terminal\n\n› Implement {feature}'),
+      false
+    );
+    // Idle composer: no interrupt hint anywhere on screen.
+    assert.strictEqual(
+      isCodexScreenIdle('─ Worked for 53m 07s ─────\n\n› Implement {feature}\n\n  gpt-5.6-sol xhigh'),
+      true
+    );
+    assert.strictEqual(isCodexScreenIdle(''), true);
   });
 
   test('a long message with no parseable sender still nudges within one chunk', () => {


### PR DESCRIPTION
Codex delivery is notify-only, but a cmux notification never starts a turn — idle Codex agents sat on queued swarm messages until a human manually prompted them (observed today with the Newsroom P0/P1 assignments). Fix: after notify, read the screen; if no `esc to interrupt` turn indicator, the composer is idle and we follow with the one-line nudge + Enter, which starts a turn whose awareness hook reads the inbox. Mid-turn or unreadable screens keep today's behavior. +test for the idle discriminator; 99/99 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151SVT6xzcsEKLLPFp6PKNb