### PR TITLE
swarm inbox --recent: cursor-free replay of past messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import {
   updateStatus,
   updateWorkspace,
 } from './registry.js';
-import { sendMessage, broadcastMessage, getInbox } from './mailbox.js';
+import { sendMessage, broadcastMessage, getInbox, getRecentMessages } from './mailbox.js';
 import { redeliverPending, runRedeliverWorker, spawnRedeliverWorker, hasPendingRedeliveries } from './redeliver.js';
 import { readScreen, identify, spawnSurfaceInWorkspace, spawnWorkspace, renameTab, moveSurface, listWorkspaces, renameWorkspace, sendToSurface, sleep } from './transport.js';
 import { installHook, removeHook, detectHost } from './hooks.js';
@@ -165,8 +165,9 @@ Communication:
                                                      default single Enter queues mid-turn
   swarm broadcast <message>                        Send to all agents in the current swarm
     [--interject|--now]
-  swarm inbox [--peek|--unread]                    Read pending messages
-                                                     (--unread is an alias; --peek does not advance cursor)
+  swarm inbox [--peek|--unread|--recent [N]]       Read pending messages
+                                                     (--unread is an alias; --peek does not advance cursor;
+                                                      --recent N replays last N regardless of cursor)
   swarm redeliver [--dry-run]                      Re-push queued messages recipients haven't seen
 
 Status:
@@ -608,6 +609,24 @@ async function main() {
         const { db, self } = requireSelf();
         // --unread: common agent habit; same as default (show unread, advance cursor).
         // --peek: show without advancing.
+        // --recent [N]: replay last N messages (default 10) IGNORING the read
+        // cursor, never advancing it — recovers messages the awareness hook
+        // already consumed (agents otherwise stall on "empty inbox").
+        if (hasFlag('--recent')) {
+          const limitRaw = getFlag('--recent');
+          const limit = limitRaw && /^\d+$/.test(limitRaw) ? parseInt(limitRaw, 10) : 10;
+          const recent = getRecentMessages(db, self.swarm_id, self.name, limit);
+          if (recent.length === 0) {
+            console.log('No messages on record.');
+          } else {
+            for (const msg of recent) {
+              const time = new Date(msg.created_at).toLocaleTimeString();
+              console.log(`[${time}] ${msg.from_agent}: ${msg.body}`);
+            }
+            console.log(`\n${recent.length} recent message(s) (replay — cursor unchanged)`);
+          }
+          break;
+        }
         const peek = hasFlag('--peek');
         const messages = getInbox(db, self.swarm_id, self.name, peek);
         if (messages.length === 0) {

--- a/src/mailbox.ts
+++ b/src/mailbox.ts
@@ -137,3 +137,28 @@ export function getInbox(
 
   return messages;
 }
+
+/**
+ * Replay the last N messages addressed to this agent REGARDLESS of the read
+ * cursor, never advancing it. Exists because the awareness hook consumes
+ * messages into a turn's context (advancing the cursor) — an agent that missed
+ * the hook output then sees an empty `swarm inbox` and stalls on stale state
+ * (field-observed three times on 2026-07-14). `swarm inbox --recent` gives
+ * agents a way to re-read what the hook already consumed.
+ */
+export function getRecentMessages(
+  db: Database.Database,
+  swarmId: string,
+  agentName: string,
+  limit: number = 10
+): Message[] {
+  const messages = db.prepare(`
+    SELECT * FROM messages
+    WHERE swarm_id = ?
+      AND (to_agent = ? COLLATE NOCASE OR to_agent IS NULL)
+      AND from_agent != ? COLLATE NOCASE
+    ORDER BY id DESC
+    LIMIT ?
+  `).all(swarmId, agentName, agentName, limit) as Message[];
+  return messages.reverse();
+}


### PR DESCRIPTION
Agents stall when the awareness hook silently consumes an approval (cursor advances, later `swarm inbox` shows empty, agent concludes it's still waiting). Three incidents today. `--recent [N]` replays the last N (default 10) messages regardless of cursor and never advances it. All 99 existing tests green; manual smoke verified replay of already-consumed messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151SVT6xzcsEKLLPFp6PKNb