### PR TITLE
fix: reject flag-like agent names; spawn --help prints help

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -742,6 +742,11 @@ async function main() {
       }
 
       case 'spawn': {
+        // `swarm spawn --help` must not spawn a tab (it once did).
+        if (hasFlag('--help') || hasFlag('-h')) {
+          printHelp();
+          break;
+        }
         const db = getDb();
         const swarm = resolveSelectedSwarm(db, true);
         const name = getFlag('--name');

--- a/src/reserved-names.ts
+++ b/src/reserved-names.ts
@@ -74,7 +74,21 @@ export function assertNotModelName(name: string): void {
   }
 }
 
+/**
+ * A name that starts with "-" is almost always a flag that fell through to
+ * the positional slot (`swarm join --help` once registered an agent literally
+ * named "--help", clobbering a real registration on the same surface).
+ */
+export function assertValidAgentName(name: string): void {
+  if (!name || name.startsWith('-')) {
+    throw new Error(
+      `"${name}" is not a valid agent name (looks like a flag). For usage, run: swarm help`
+    );
+  }
+}
+
 export function assertNameNotReserved(name: string): void {
+  assertValidAgentName(name);
   assertNotModelName(name);
   const reserved = loadReservedNames();
   if (reserved.has(name.toLowerCase())) {

--- a/tests/reserved-names.test.ts
+++ b/tests/reserved-names.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { assertNameNotReserved, loadReservedNames } from '../src/reserved-names.js';
+import { assertNameNotReserved, assertValidAgentName, loadReservedNames } from '../src/reserved-names.js';
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_ENV = process.env.SWARM_RESERVED_NAMES;
@@ -66,6 +66,24 @@ describe('model-name policy', () => {
 
     for (const ok of ['Scribe', 'Rivet', 'Yulan', 'Pixel2', 'Sol', 'Brillo']) {
       assert.doesNotThrow(() => assertNameNotReserved(ok), ok);
+    }
+  });
+});
+
+describe('flag-like agent names', () => {
+  test('rejects names that look like flags (the swarm join --help incident)', () => {
+    delete process.env.SWARM_RESERVED_NAMES;
+    delete process.env.SWARM_RESERVED_NAMES_FILE;
+    process.env.HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'swarm-reserved-'));
+
+    for (const bad of ['--help', '-h', '--force', '-x', '']) {
+      assert.throws(() => assertNameNotReserved(bad), /not a valid agent name|looks like a flag/i, JSON.stringify(bad));
+    }
+  });
+
+  test('assertValidAgentName passes ordinary names through', () => {
+    for (const ok of ['Pixel', 'a', 'name-with-dash-inside']) {
+      assert.doesNotThrow(() => assertValidAgentName(ok), ok);
     }
   });
 });


### PR DESCRIPTION
Live incident 2026-07-16: `swarm join --help` registered an agent named `--help`, overwriting a real registration on the same surface; `swarm spawn --help` spawned a stray tab.

- `assertValidAgentName`: names that are empty or start with `-` are rejected with a pointer to `swarm help` (enforced through `assertNameNotReserved`, so join/register-a2a/spawn --name all inherit it)
- `spawn` handles `--help`/`-h` explicitly instead of spawning

106/106 tests (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKjgiFi8GbYFunRf8wXkAU