### PR TITLE
Fix stale Codex swarm nudges

### DIFF
--- a/src/cmux-transport.ts
+++ b/src/cmux-transport.ts
@@ -1,5 +1,5 @@
 import { Transport, TransportAgent, TransportDeliveryResult, DeliveryOptions } from './transport-interface.js';
-import { sendToSurface, notifySurface, readScreen, SurfaceGoneError, isSurfaceAlive } from './transport.js';
+import { sendToSurface, notifySurface, SurfaceGoneError, isSurfaceAlive } from './transport.js';
 
 // A keystroke push is reliable only for a single short send. Typing a long,
 // multi-chunk message into a live Claude Code TUI silently drops chunks (the
@@ -46,11 +46,32 @@ export function prefersNotifyDelivery(hostAgent: string | null | undefined, opti
  * observed 2026-07-14: assignments went undelivered until Tom manually nudged).
  * Keystroke injection is only dangerous MID-turn (pickers, queued input); when
  * the composer is idle, typing a one-line nudge + Enter is safe and starts a
- * turn whose awareness hook reads the inbox. Discriminator: Codex renders
- * "esc to interrupt" on its status line for the entire duration of a turn.
+ * turn whose awareness hook reads the inbox. Absence of "esc to interrupt" is
+ * not sufficient proof of idleness: Codex can briefly omit that status between
+ * tool/status frames. Require the completed-turn boundary immediately above
+ * the composer plus the Codex model footer so ambiguous frames fail closed.
  */
 export function isCodexScreenIdle(screen: string): boolean {
-  return !/esc to interrupt/i.test(screen);
+  if (/esc to interrupt|^\s*•\s+Working\b/im.test(screen)) return false;
+
+  const lines = screen.replace(/\r/g, '').split('\n');
+  let promptIndex = -1;
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    if (/^\s*›(?:\s|$)/u.test(lines[i])) {
+      promptIndex = i;
+      break;
+    }
+  }
+  if (promptIndex < 0) return false;
+
+  const hasModelFooter = lines.slice(promptIndex + 1).some(line => /\bgpt-[\w.-]+\b/i.test(line));
+  if (!hasModelFooter) return false;
+
+  let previous = promptIndex - 1;
+  while (previous >= 0 && lines[previous].trim() === '') previous -= 1;
+  if (previous < 0) return false;
+
+  return /^\s*─(?:─+| Worked for\b.*─+)\s*$/u.test(lines[previous]);
 }
 
 export class CmuxTransport implements Transport {
@@ -80,10 +101,11 @@ export class CmuxTransport implements Transport {
         // start a turn; if it's mid-turn (or the read fails), the notify + the
         // agent's own task-boundary inbox checks cover it.
         try {
-          const screen = readScreen(agent.surface_id, 30, agent.workspace_id);
-          if (isCodexScreenIdle(screen)) {
-            sendToSurface(agent.surface_id, pushText, agent.workspace_id, { enterCount: 1 });
-          }
+          sendToSurface(agent.surface_id, pushText, agent.workspace_id, {
+            enterCount: 1,
+            screenGuard: isCodexScreenIdle,
+            screenGuardLines: 30,
+          });
         } catch {
           // Best-effort wake only — notify already succeeded, message is queued.
         }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -134,6 +134,15 @@ export interface SendToSurfaceOptions {
    * on the first. Default 1.
    */
   enterCount?: number;
+  /**
+   * Optional fail-closed screen predicate evaluated while the per-surface lock
+   * is held. The predicate must pass twice, separated by confirmDelaySeconds,
+   * before any keystrokes are sent. This makes a readiness check atomic with
+   * the send and filters transient TUI frames.
+   */
+  screenGuard?: (screen: string) => boolean;
+  screenGuardLines?: number;
+  confirmDelaySeconds?: number;
 }
 
 /**
@@ -180,13 +189,31 @@ export function sendToSurface(
   text: string,
   workspaceId?: string | null,
   options?: SendToSurfaceOptions
-): void {
+): boolean {
   const cmux = resolveCmux();
   const safe = sanitize(text);
   const enterCount = Math.max(1, options?.enterCount ?? 1);
   const wsArgs = workspaceId ? ['--workspace', workspaceId] : [];
   const lockPath = acquireSurfaceLock(surfaceId);
   try {
+    if (options?.screenGuard) {
+      // Unguarded sends may retain the historical timeout fallback, but a
+      // readiness-conditional send must never race another writer.
+      if (!lockPath) return false;
+      try {
+        const lines = options.screenGuardLines ?? 30;
+        const first = readScreen(surfaceId, lines, workspaceId);
+        if (!options.screenGuard(first)) return false;
+        sleep(options.confirmDelaySeconds ?? 0.25);
+        const second = readScreen(surfaceId, lines, workspaceId);
+        if (!options.screenGuard(second)) return false;
+      } catch {
+        // A guard is advisory wake-up logic. If the screen cannot be proven
+        // safe, leave the durable inbox row for the recipient's next check.
+        return false;
+      }
+    }
+
     for (let attempt = 0; attempt < MAX_SEND_ATTEMPTS; attempt++) {
       try {
         // Before a RETRY, clear the input line: a prior attempt may have typed
@@ -214,7 +241,7 @@ export function sendToSurface(
           execFileSync(cmux, ['send-key', ...wsArgs, '--surface', surfaceId, 'Enter'], STDIO_OPTS);
           if (e + 1 < enterCount) sleep(0.05);
         }
-        return; // success
+        return true; // success
       } catch (err: any) {
         // A "broken pipe"/socket-reset means the cmux server dropped the connection
         // under load — the surface is alive but momentarily busy (recipient mid-turn).
@@ -232,6 +259,7 @@ export function sendToSurface(
         throw new SurfaceGoneError(surfaceId);
       }
     }
+    return false;
   } finally {
     releaseSurfaceLock(lockPath);
   }

--- a/tests/transport.test.ts
+++ b/tests/transport.test.ts
@@ -1,6 +1,9 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
-import { isTransientCmuxError } from '../src/transport.js';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { isTransientCmuxError, sendToSurface } from '../src/transport.js';
 import { buildPushText, enterCountForDelivery, prefersNotifyDelivery, isCodexScreenIdle, PUSH_MAX_CHARS } from '../src/cmux-transport.js';
 
 // The transient/gone classification decides whether a failed cmux send is retried
@@ -96,7 +99,7 @@ describe('buildPushText (single-chunk push, nudge for long messages)', () => {
     assert.strictEqual(prefersNotifyDelivery(null), false);
   });
 
-  test('Codex idle detection keys off the "esc to interrupt" turn indicator', () => {
+  test('Codex idle detection requires a completed-turn boundary at the composer', () => {
     // Mid-turn: status line shows the interrupt hint for the whole turn.
     assert.strictEqual(
       isCodexScreenIdle('• Working (49s • esc to interrupt) · 1 background terminal\n\n› Implement {feature}'),
@@ -107,12 +110,74 @@ describe('buildPushText (single-chunk push, nudge for long messages)', () => {
       isCodexScreenIdle('─ Worked for 53m 07s ─────\n\n› Implement {feature}\n\n  gpt-5.6-sol xhigh'),
       true
     );
-    assert.strictEqual(isCodexScreenIdle(''), true);
+    assert.strictEqual(
+      isCodexScreenIdle('• Final answer\n────────────────────────\n\n› Implement {feature}\n\n  gpt-5.6-luna low'),
+      true
+    );
+  });
+
+  test('Codex idle detection rejects ambiguous frames without a completed-turn boundary', () => {
+    // A screen read can briefly omit the working indicator between tool/status
+    // frames. Treating that absence as idle queues a nudge behind the active
+    // turn; it surfaces later after the matching inbox row has been consumed.
+    assert.strictEqual(
+      isCodexScreenIdle('• Ran npm test\n  └ 120 tests passed\n\n› Implement {feature}\n\n  gpt-5.6-sol xhigh'),
+      false
+    );
+    assert.strictEqual(isCodexScreenIdle(''), false);
   });
 
   test('a long message with no parseable sender still nudges within one chunk', () => {
     const push = buildPushText('x'.repeat(500));
     assert.ok(push.length <= PUSH_MAX_CHARS);
     assert.match(push, /inbox/);
+  });
+});
+
+describe('sendToSurface screen guard', () => {
+  test('fails closed on an ambiguous frame and sends only after a confirmed idle frame', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'swarm-screen-guard-'));
+    const fakeCmux = join(dir, 'cmux');
+    const log = join(dir, 'cmux.log');
+    const priorPath = process.env.PATH;
+    const priorScreen = process.env.SWARM_TEST_SCREEN;
+    const priorLog = process.env.SWARM_TEST_LOG;
+
+    writeFileSync(fakeCmux, `#!/bin/sh
+if [ "$1" = "read-screen" ]; then
+  printf "%s" "$SWARM_TEST_SCREEN"
+  exit 0
+fi
+printf "%s\\n" "$*" >> "$SWARM_TEST_LOG"
+`);
+    chmodSync(fakeCmux, 0o755);
+
+    try {
+      process.env.PATH = `${dir}:${priorPath ?? ''}`;
+      process.env.SWARM_TEST_LOG = log;
+      process.env.SWARM_TEST_SCREEN = '• Ran npm test\n  └ 120 tests passed\n\n› Implement {feature}\n\n  gpt-5.6-sol xhigh';
+
+      const skipped = sendToSurface('SCREEN-GUARD-TEST', 'nudge', null, {
+        screenGuard: isCodexScreenIdle,
+        confirmDelaySeconds: 0,
+      });
+      assert.strictEqual(skipped, false);
+
+      process.env.SWARM_TEST_SCREEN = '─ Worked for 1s ─────\n\n› Implement {feature}\n\n  gpt-5.6-sol xhigh';
+      const sent = sendToSurface('SCREEN-GUARD-TEST', 'nudge', null, {
+        screenGuard: isCodexScreenIdle,
+        confirmDelaySeconds: 0,
+      });
+      assert.strictEqual(sent, true);
+      assert.match(readFileSync(log, 'utf8'), /^send .*nudge[\s\S]*send-key .*Enter/m);
+    } finally {
+      if (priorPath === undefined) delete process.env.PATH;
+      else process.env.PATH = priorPath;
+      if (priorScreen === undefined) delete process.env.SWARM_TEST_SCREEN;
+      else process.env.SWARM_TEST_SCREEN = priorScreen;
+      if (priorLog === undefined) delete process.env.SWARM_TEST_LOG;
+      else process.env.SWARM_TEST_LOG = priorLog;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- require positive completed-turn evidence before injecting an idle Codex nudge
- evaluate the screen guard twice while holding the per-surface send lock
- fail closed on ambiguous screens, read failures, and lock timeouts

## Root cause
The old negative idle check treated any frame without the interrupt hint as idle. Transient Codex frames and concurrent sends could therefore queue a nudge behind an active turn. The nudge surfaced minutes later after its inbox row had already been consumed, appearing as a phantom alert.

## Verification
- npm test: 108/108 pass
- npm run build: pass
- live idle wake positive control: pass
- live concurrent A/B control: one nudge delivered both inbox rows
- git diff --check: pass